### PR TITLE
Add some simplistic parsing and some concept of variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,10 @@ members = [
     "gui-derive",
     "gui-core",
     "gui-widget",
+    "gui-build",
 #    "examples/**",
-    "examples/shello"
+    "examples/shello",
+    "examples/testbed"
 ]
 
 [package]
@@ -18,3 +20,6 @@ edition = "2021"
 [dependencies]
 gui-core = { version = "0.1.0", path = "./gui-core" }
 gui-widget = { version = "0.1.0", path = "./gui-widget" }
+instant = "0.1.12"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+pollster = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
     "gui-widget",
     "gui-build",
 #    "examples/**",
-    "examples/shello",
+#    "examples/shello",
     "examples/testbed"
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-vello = { git = "https://github.com/linebender/vello", rev = "9d7c4f00d8db420337706771a37937e9025e089c" }
-parley = { git = "https://github.com/dfrg/parley", rev = "2371bf4b702ec91edee2d58ffb2d432539580e1e" }
-glazier = { git = "https://github.com/linebender/glazier/", rev = "b79dd1b4daf635cfcd0aca149a26bab6cb9e0972" }
+gui-core = { version = "0.1.0", path = "./gui-core" }
+gui-widget = { version = "0.1.0", path = "./gui-widget" }

--- a/examples/counter/gui.yaml
+++ b/examples/counter/gui.yaml
@@ -21,7 +21,6 @@ components:
         type: bool
     child:
       name: VStack  # Widget/Component names must be unique for this component
-      type: widget
       widget: VStack
       layoutProperties: # Under the hood these settings create a layout widget
                         # so that custom widgets do not need to deal with layout.

--- a/examples/counter/gui.yaml
+++ b/examples/counter/gui.yaml
@@ -45,10 +45,10 @@ components:
           - name: DecrementBtn
             widget: Button
             properties:
+              disabled:
+                variable: disabled_decrement
               child:
                 name: DecrText
                 widget: Text
                 properties:
                   text: Decrement
-                  disabled:
-                    variable: disabled_decrement

--- a/examples/shello/src/main.rs
+++ b/examples/shello/src/main.rs
@@ -1,62 +1,6 @@
 use std::any::Any;
 use tracing_subscriber::EnvFilter;
 
-mod common {
-    pub mod text {
-        use gui::parley::Layout;
-        use gui::vello::kurbo::Affine;
-        use gui::vello::{
-            glyph::{fello::raw::FontRef, GlyphContext},
-            peniko::{Brush, Color},
-            *,
-        };
-
-        #[derive(Clone, PartialEq, Debug)]
-        pub struct ParleyBrush(pub Brush);
-
-        impl Default for ParleyBrush {
-            fn default() -> ParleyBrush {
-                ParleyBrush(Brush::Solid(Color::rgb8(0, 0, 0)))
-            }
-        }
-
-        impl gui::parley::style::Brush for ParleyBrush {}
-
-        pub fn render_text(
-            builder: &mut SceneBuilder,
-            transform: Affine,
-            layout: &Layout<ParleyBrush>,
-        ) {
-            let mut gcx = GlyphContext::new();
-            for line in layout.lines() {
-                for glyph_run in line.glyph_runs() {
-                    let mut x = glyph_run.offset();
-                    let y = glyph_run.baseline();
-                    let run = glyph_run.run();
-                    let font = run.font();
-                    let font_size = run.font_size();
-                    let font_ref = font.as_ref();
-                    if let Ok(font_ref) = FontRef::from_index(font_ref.data, font.index()) {
-                        let style = glyph_run.style();
-                        let vars: [(&str, f32); 0] = [];
-                        let mut gp = gcx.new_provider(&font_ref, None, font_size, false, vars);
-                        for glyph in glyph_run.glyphs() {
-                            if let Some(fragment) = gp.get(glyph.id, Some(&style.brush.0)) {
-                                let gx = x + glyph.x;
-                                let gy = y - glyph.y;
-                                let xform = Affine::translate((gx as f64, gy as f64))
-                                    * Affine::scale_non_uniform(1.0, -1.0);
-                                builder.append(&fragment, Some(transform * xform));
-                            }
-                            x += glyph.advance;
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
 #[cfg(feature = "accesskit")]
 use accesskit::TreeUpdate;
 use gui::parley::FontContext;

--- a/examples/testbed/Cargo.toml
+++ b/examples/testbed/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "testbed"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+gui = {path = "../../."}
+gui-widget = {path = "../../gui-widget"}
+
+[build-dependencies]
+gui-build = {path = "../../gui-build"}
+gui-widget = {path = "../../gui-widget"}

--- a/examples/testbed/Cargo.toml
+++ b/examples/testbed/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 gui = {path = "../../."}
 gui-widget = {path = "../../gui-widget"}
+rand = "0.8.5"
 
 [build-dependencies]
 gui-build = {path = "../../gui-build"}

--- a/examples/testbed/build.rs
+++ b/examples/testbed/build.rs
@@ -1,0 +1,5 @@
+extern crate gui_widget;
+
+fn main() {
+    gui_build::build("simple.yaml");
+}

--- a/examples/testbed/simple.yaml
+++ b/examples/testbed/simple.yaml
@@ -11,4 +11,4 @@ components:
       name: Count
       widget: Text
       properties:
-        text: Hi
+        text: Hi Alec!

--- a/examples/testbed/simple.yaml
+++ b/examples/testbed/simple.yaml
@@ -1,8 +1,7 @@
 styles:
   - widget: Text
     properties:
-      colour: "#ffffff"
-      font: arial
+      colour: "#ffff00"
       size: 12
 
 components:
@@ -12,3 +11,5 @@ components:
       widget: Text
       properties:
         text: Hi Alec!
+        size: 15
+#        colour: "#00ff00"

--- a/examples/testbed/simple.yaml
+++ b/examples/testbed/simple.yaml
@@ -6,10 +6,15 @@ styles:
 
 components:
   - name: Counter # Names for components must be unique
+    variables:
+      - name: test
+        type: String
     child:
       name: Count
       widget: Text
       properties:
-        text: Hi Alec!
+        text:
+          variable:
+            test
         size: 15
 #        colour: "#00ff00"

--- a/examples/testbed/src/main.rs
+++ b/examples/testbed/src/main.rs
@@ -1,3 +1,20 @@
+use gui::gui_core::{Component, Update};
+use rand::distributions::{Alphanumeric, DistString};
+
+struct Counter {
+    widget: ::gui_widget::Text,
+}
+include!(concat!(env!("OUT_DIR"), "/Counter.rs"));
+impl Update<gen::test> for Counter {
+    fn is_updated(&self) -> bool {
+        true
+    }
+    fn value(&self) -> String {
+        Alphanumeric.sample_string(&mut rand::thread_rng(), 16)
+        // String::new()
+    }
+}
+
 fn main() {
-    gui::run(include!(concat!(env!("OUT_DIR"), "/widget.rs")))
+    gui::run(Counter::new())
 }

--- a/examples/testbed/src/main.rs
+++ b/examples/testbed/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    gui::run(include!(concat!(env!("OUT_DIR"), "/widget.rs")))
+}

--- a/examples/testbed/src/main.rs
+++ b/examples/testbed/src/main.rs
@@ -4,6 +4,8 @@ use rand::distributions::{Alphanumeric, DistString};
 struct Counter {
     widget: ::gui_widget::Text,
 }
+use Counter as CompStruct;
+
 include!(concat!(env!("OUT_DIR"), "/Counter.rs"));
 impl Update<gen::test> for Counter {
     fn is_updated(&self) -> bool {

--- a/gui-build/Cargo.toml
+++ b/gui-build/Cargo.toml
@@ -10,3 +10,4 @@ gui-core = { version = "0.1.0", path = "./../gui-core" }
 serde_yaml = "0.9.30"
 anyhow = "1.0.79"
 proc-macro2 = "1.0.76"
+quote = "1.0.35"

--- a/gui-build/Cargo.toml
+++ b/gui-build/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "gui-widget"
+name = "gui-build"
 version = "0.1.0"
 edition = "2021"
 
@@ -8,7 +8,5 @@ edition = "2021"
 [dependencies]
 gui-core = { version = "0.1.0", path = "./../gui-core" }
 serde_yaml = "0.9.30"
-typetag = "0.2.15"
-serde = { version = "1.0.195", features = ["derive"] }
-proc-macro2 = { version = "1.0.76", features = [] }
-quote = "1.0.35"
+anyhow = "1.0.79"
+proc-macro2 = "1.0.76"

--- a/gui-build/src/lib.rs
+++ b/gui-build/src/lib.rs
@@ -64,7 +64,6 @@ fn create_component(out_dir: &Path, component: &mut ComponentDeclaration) -> any
     component.child.widget.create_widget(&mut stream);
 
     let path = Path::new(&out_dir).join(format!("{}.rs", component.name));
-    let comp_name = Ident::new(&component.name, Span::call_site());
 
     let update_vars: TokenStream = component
         .variables
@@ -123,7 +122,7 @@ fn create_component(out_dir: &Path, component: &mut ComponentDeclaration) -> any
                     use gui::gui_core::{Update, Variable, Component};
                     use gui::gui_core::vello::SceneBuilder;
                     use gui::gui_core::parley::font::FontContext;
-                    use super::#comp_name as CompStruct;
+                    use super::CompStruct;
 
                     #struct_vars
 

--- a/gui-build/src/lib.rs
+++ b/gui-build/src/lib.rs
@@ -1,0 +1,28 @@
+use anyhow::anyhow;
+use gui_core::parse::GUIDeclaration;
+use proc_macro2::TokenStream;
+use std::fs::File;
+use std::path::Path;
+use std::{env, fs};
+
+pub fn build<P: AsRef<Path>>(path: P) {
+    build_path(path.as_ref()).unwrap()
+}
+
+fn build_path(path: &Path) -> anyhow::Result<()> {
+    println!("cargo:rerun-if-changed={}", path.display());
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let file = File::open(path)?;
+    let out_dir = env::var_os("OUT_DIR").ok_or_else(|| anyhow!("could not find OUT_DIR env"))?;
+    let ser: GUIDeclaration = serde_yaml::from_reader(file)?;
+    let mut stream = TokenStream::new();
+    ser.components[0].child.widget.create_widget(&mut stream);
+    let path = Path::new(&out_dir).join("widget.rs");
+    fs::write(path, format!("{}", stream))?;
+    dbg!(ser);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {}

--- a/gui-build/src/lib.rs
+++ b/gui-build/src/lib.rs
@@ -1,11 +1,13 @@
 use anyhow::{anyhow, bail};
-use gui_core::parse::GUIDeclaration;
+use gui_core::parse::{ComponentDeclaration, GUIDeclaration, VariableDeclaration};
 use gui_core::widget::AsAny;
-use proc_macro2::TokenStream;
-use std::any::{Any, TypeId};
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+use std::any::TypeId;
 use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
+use std::str::FromStr;
 use std::{env, fs};
 
 pub fn build<P: AsRef<Path>>(path: P) {
@@ -18,15 +20,15 @@ fn build_path(path: &Path) -> anyhow::Result<()> {
 
     let file = File::open(path)?;
     let out_dir = env::var_os("OUT_DIR").ok_or_else(|| anyhow!("could not find OUT_DIR env"))?;
+    let path = Path::new(&out_dir);
     let mut ser: GUIDeclaration = serde_yaml::from_reader(file)?;
-    let mut stream = TokenStream::new();
 
     combine_styles(&mut ser)?;
 
-    ser.components[0].child.widget.create_widget(&mut stream);
+    for component in ser.components.iter_mut() {
+        create_component(path, component)?;
+    }
 
-    let path = Path::new(&out_dir).join("widget.rs");
-    fs::write(path, format!("{}", stream))?;
     Ok(())
 }
 
@@ -53,6 +55,97 @@ fn combine_styles(static_gui: &mut GUIDeclaration) -> anyhow::Result<()> {
             c.child.widget.combine(static_gui.styles[*i].as_ref())
         }
     }
+
+    Ok(())
+}
+
+fn create_component(out_dir: &Path, component: &mut ComponentDeclaration) -> anyhow::Result<()> {
+    let mut stream = TokenStream::new();
+    component.child.widget.create_widget(&mut stream);
+
+    let path = Path::new(&out_dir).join(format!("{}.rs", component.name));
+    let comp_name = Ident::new(&component.name, Span::call_site());
+
+    let update_vars: TokenStream = component
+        .variables
+        .iter()
+        .filter_map(|v| {
+            if let VariableDeclaration::Normal(n) = v {
+                let mut stream = TokenStream::new();
+                let var_name = Ident::new(&n.name, Span::call_site());
+                let widget = Ident::new("widget", Span::call_site());
+                let value = Ident::new("value", Span::call_site());
+                component
+                    .child
+                    .widget
+                    .on_var_update(&widget, &n.name, &value, &mut stream);
+                Some(quote! {
+                    if force_update || <Self as Update<#var_name>>::is_updated(self) {
+                        let #value = <Self as Update<#var_name>>::value(self);
+                        let #widget = &mut self.widget;
+                        #stream
+                    }
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let struct_vars: TokenStream = component
+        .variables
+        .iter()
+        .filter_map(|v| {
+            if let VariableDeclaration::Normal(n) = v {
+                let name = Ident::new(&n.name, Span::call_site());
+                let var_type = TokenStream::from_str(&n.var_type).expect("a valid type");
+                Some(quote! {
+                    #[allow(non_camel_case_types)]
+                    pub(crate) struct #name;
+
+                    impl Variable for #name {
+                        type VarType = #var_type;
+                    }
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    fs::write(
+        path,
+        format!(
+            "{}",
+            quote! {
+                mod gen {
+                    use gui::gui_core::widget::Widget;
+                    use gui::gui_core::{Update, Variable, Component};
+                    use gui::gui_core::vello::SceneBuilder;
+                    use gui::gui_core::parley::font::FontContext;
+                    use super::#comp_name as CompStruct;
+
+                    #struct_vars
+
+                    impl Component for CompStruct {
+                        fn new() -> Self where Self: Sized {
+                            CompStruct {
+                                widget: #stream
+                            }
+                        }
+
+                        fn render(&mut self, scene: SceneBuilder, fcx: &mut FontContext) {
+                            self.widget.render(scene, fcx);
+                        }
+
+                        fn update_vars(&mut self, force_update: bool) {
+                            #update_vars
+                        }
+                    }
+                }
+            }
+        ),
+    )?;
 
     Ok(())
 }

--- a/gui-build/src/lib.rs
+++ b/gui-build/src/lib.rs
@@ -1,6 +1,9 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use gui_core::parse::GUIDeclaration;
+use gui_core::widget::AsAny;
 use proc_macro2::TokenStream;
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
 use std::{env, fs};
@@ -15,12 +18,42 @@ fn build_path(path: &Path) -> anyhow::Result<()> {
 
     let file = File::open(path)?;
     let out_dir = env::var_os("OUT_DIR").ok_or_else(|| anyhow!("could not find OUT_DIR env"))?;
-    let ser: GUIDeclaration = serde_yaml::from_reader(file)?;
+    let mut ser: GUIDeclaration = serde_yaml::from_reader(file)?;
     let mut stream = TokenStream::new();
+
+    combine_styles(&mut ser)?;
+
     ser.components[0].child.widget.create_widget(&mut stream);
+
     let path = Path::new(&out_dir).join("widget.rs");
     fs::write(path, format!("{}", stream))?;
-    dbg!(ser);
+    Ok(())
+}
+
+fn combine_styles(static_gui: &mut GUIDeclaration) -> anyhow::Result<()> {
+    let mut styles: HashMap<TypeId, usize> = HashMap::new();
+
+    for (t, i) in static_gui
+        .styles
+        .iter()
+        .enumerate()
+        .map(|(i, s)| (s.as_any().type_id(), i))
+    {
+        if styles.insert(t, i).is_some() {
+            bail!(
+                "Found multiple styles for widget {}",
+                static_gui.styles[i].name()
+            )
+        }
+    }
+
+    for c in &mut static_gui.components {
+        let widget = &c.child.widget;
+        if let Some(i) = styles.get(&(widget.as_any().type_id())) {
+            c.child.widget.combine(static_gui.styles[*i].as_ref())
+        }
+    }
+
     Ok(())
 }
 

--- a/gui-core/Cargo.toml
+++ b/gui-core/Cargo.toml
@@ -13,3 +13,4 @@ typetag = "0.2.15"
 serde = { version = "1.0.195", features = ["derive"] }
 serde_yaml = "0.9.30"
 proc-macro2 = "1.0.76"
+quote = "1.0.35"

--- a/gui-core/Cargo.toml
+++ b/gui-core/Cargo.toml
@@ -12,3 +12,4 @@ glazier = { git = "https://github.com/linebender/glazier/", rev = "b79dd1b4daf63
 typetag = "0.2.15"
 serde = { version = "1.0.195", features = ["derive"] }
 serde_yaml = "0.9.30"
+proc-macro2 = "1.0.76"

--- a/gui-core/Cargo.toml
+++ b/gui-core/Cargo.toml
@@ -6,3 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+vello = { git = "https://github.com/linebender/vello", rev = "9d7c4f00d8db420337706771a37937e9025e089c" }
+parley = { git = "https://github.com/dfrg/parley", rev = "2371bf4b702ec91edee2d58ffb2d432539580e1e" }
+glazier = { git = "https://github.com/linebender/glazier/", rev = "b79dd1b4daf635cfcd0aca149a26bab6cb9e0972" }
+typetag = "0.2.15"
+serde = { version = "1.0.195", features = ["derive"] }
+serde_yaml = "0.9.30"

--- a/gui-core/src/common.rs
+++ b/gui-core/src/common.rs
@@ -1,0 +1,1 @@
+pub mod text;

--- a/gui-core/src/common/text.rs
+++ b/gui-core/src/common/text.rs
@@ -1,0 +1,47 @@
+use parley::Layout;
+use vello::kurbo::Affine;
+use vello::{
+    glyph::{fello::raw::FontRef, GlyphContext},
+    peniko::{Brush, Color},
+    *,
+};
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct ParleyBrush(pub Brush);
+
+impl Default for ParleyBrush {
+    fn default() -> ParleyBrush {
+        ParleyBrush(Brush::Solid(Color::rgb8(0, 0, 0)))
+    }
+}
+
+impl parley::style::Brush for ParleyBrush {}
+
+pub fn render_text(builder: &mut SceneBuilder, transform: Affine, layout: &Layout<ParleyBrush>) {
+    let mut gcx = GlyphContext::new();
+    for line in layout.lines() {
+        for glyph_run in line.glyph_runs() {
+            let mut x = glyph_run.offset();
+            let y = glyph_run.baseline();
+            let run = glyph_run.run();
+            let font = run.font();
+            let font_size = run.font_size();
+            let font_ref = font.as_ref();
+            if let Ok(font_ref) = FontRef::from_index(font_ref.data, font.index()) {
+                let style = glyph_run.style();
+                let vars: [(&str, f32); 0] = [];
+                let mut gp = gcx.new_provider(&font_ref, None, font_size, false, vars);
+                for glyph in glyph_run.glyphs() {
+                    if let Some(fragment) = gp.get(glyph.id, Some(&style.brush.0)) {
+                        let gx = x + glyph.x;
+                        let gy = y - glyph.y;
+                        let xform = Affine::translate((gx as f64, gy as f64))
+                            * Affine::scale_non_uniform(1.0, -1.0);
+                        builder.append(&fragment, Some(transform * xform));
+                    }
+                    x += glyph.advance;
+                }
+            }
+        }
+    }
+}

--- a/gui-core/src/lib.rs
+++ b/gui-core/src/lib.rs
@@ -1,4 +1,9 @@
-mod widget;
+pub mod common;
+pub mod parse;
+pub mod widget;
+
+pub use parse::colour::Colour;
+pub use parse::var::Var;
 
 pub fn add(left: usize, right: usize) -> usize {
     left + right

--- a/gui-core/src/lib.rs
+++ b/gui-core/src/lib.rs
@@ -12,6 +12,28 @@ pub use vello;
 pub use parley::font::FontContext;
 pub use vello::SceneBuilder;
 
+struct TestBoxable {
+    test: Box<dyn Component>,
+}
+
+pub trait Component {
+    fn new() -> Self
+    where
+        Self: Sized;
+    fn render(&mut self, scene: SceneBuilder, fcx: &mut FontContext);
+
+    fn update_vars(&mut self, force_update: bool);
+}
+
+pub trait Variable {
+    type VarType;
+}
+
+pub trait Update<T: Variable> {
+    fn is_updated(&self) -> bool;
+    fn value(&self) -> T::VarType;
+}
+
 pub fn add(left: usize, right: usize) -> usize {
     left + right
 }

--- a/gui-core/src/lib.rs
+++ b/gui-core/src/lib.rs
@@ -5,6 +5,13 @@ pub mod widget;
 pub use parse::colour::Colour;
 pub use parse::var::Var;
 
+pub use glazier;
+pub use parley;
+pub use vello;
+
+pub use parley::font::FontContext;
+pub use vello::SceneBuilder;
+
 pub fn add(left: usize, right: usize) -> usize {
     left + right
 }

--- a/gui-core/src/lib.rs
+++ b/gui-core/src/lib.rs
@@ -12,6 +12,7 @@ pub use vello;
 pub use parley::font::FontContext;
 pub use vello::SceneBuilder;
 
+#[allow(dead_code)]
 struct TestBoxable {
     test: Box<dyn Component>,
 }

--- a/gui-core/src/parse.rs
+++ b/gui-core/src/parse.rs
@@ -1,0 +1,60 @@
+pub mod colour;
+pub mod var;
+
+use crate::widget::WidgetBuilder;
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct WidgetDeclaration {
+    pub name: Option<String>,
+    #[serde(flatten)]
+    pub widget: Box<dyn WidgetBuilder>,
+    pub layout_properties: Option<LayoutDeclaration>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct LayoutDeclaration {
+    pub padding: u32,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct NormalVariableDeclaration {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub var_type: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ComponentVariableDeclaration {
+    pub name: String,
+    pub component: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ComponentsVariableDeclaration {
+    pub name: String,
+    pub components: String,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+pub enum VariableDeclaration {
+    Normal(NormalVariableDeclaration),
+    Component(ComponentVariableDeclaration),
+    Components(ComponentsVariableDeclaration),
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ComponentDeclaration {
+    pub name: String,
+    #[serde(default)]
+    pub variables: Vec<VariableDeclaration>,
+    pub child: WidgetDeclaration,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct GUIDeclaration {
+    pub styles: Vec<Box<dyn WidgetBuilder>>,
+    pub components: Vec<ComponentDeclaration>,
+}

--- a/gui-core/src/parse/colour.rs
+++ b/gui-core/src/parse/colour.rs
@@ -1,9 +1,27 @@
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
 use serde::de::{Error, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer};
 use std::fmt::Formatter;
 
 #[derive(Debug, Copy, Clone, Default)]
-pub struct Colour(vello::peniko::Color);
+pub struct Colour(pub vello::peniko::Color);
+
+impl ToTokens for Colour {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let r = self.0.r;
+        let g = self.0.g;
+        let b = self.0.b;
+        let a = self.0.a;
+        tokens.extend(quote!(::gui::gui_core::Colour::rgba8(#r, #g, #b, #a)))
+    }
+}
+
+impl Colour {
+    pub const fn rgba8(r: u8, g: u8, b: u8, a: u8) -> Self {
+        Colour(vello::peniko::Color { r, g, b, a })
+    }
+}
 
 struct ColourVisitor;
 

--- a/gui-core/src/parse/colour.rs
+++ b/gui-core/src/parse/colour.rs
@@ -2,7 +2,7 @@ use serde::de::{Error, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer};
 use std::fmt::Formatter;
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct Colour(vello::peniko::Color);
 
 struct ColourVisitor;

--- a/gui-core/src/parse/colour.rs
+++ b/gui-core/src/parse/colour.rs
@@ -1,0 +1,34 @@
+use serde::de::{Error, Unexpected, Visitor};
+use serde::{Deserialize, Deserializer};
+use std::fmt::Formatter;
+
+#[derive(Debug)]
+pub struct Colour(vello::peniko::Color);
+
+struct ColourVisitor;
+
+impl<'de> Visitor<'de> for ColourVisitor {
+    type Value = Colour;
+
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        formatter.write_str("a colour as either in hexidecimal CSS style of the form #RGB, #RGBA, #RRGGBB, #RRGGBBAA or the name of an SVG color such as \"aliceblue\"")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        vello::peniko::Color::parse(v)
+            .ok_or_else(|| Error::invalid_value(Unexpected::Other("unrecognized colour."), &self))
+            .map(Colour)
+    }
+}
+
+impl<'de> Deserialize<'de> for Colour {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(ColourVisitor)
+    }
+}

--- a/gui-core/src/parse/var.rs
+++ b/gui-core/src/parse/var.rs
@@ -1,0 +1,9 @@
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum Var<T> {
+    Variable(String),
+    #[serde(untagged)]
+    Value(T),
+}

--- a/gui-core/src/parse/var.rs
+++ b/gui-core/src/parse/var.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum Var<T> {
     Variable(String),

--- a/gui-core/src/widget.rs
+++ b/gui-core/src/widget.rs
@@ -1,1 +1,6 @@
-pub trait Widget {}
+pub trait Widget {
+    type Builder;
+}
+
+#[typetag::deserialize(tag = "widget", content = "properties")]
+pub trait WidgetBuilder: std::fmt::Debug {}

--- a/gui-core/src/widget.rs
+++ b/gui-core/src/widget.rs
@@ -23,5 +23,5 @@ pub trait WidgetBuilder: std::fmt::Debug + AsAny {
     fn name(&self) -> &'static str;
     fn combine(&mut self, rhs: &dyn WidgetBuilder);
     fn create_widget(&self, stream: &mut TokenStream);
-    fn on_var_update(&self, widget: Ident, var: &str, value: Ident, stream: &mut TokenStream);
+    fn on_var_update(&self, widget: &Ident, var: &str, value: &Ident, stream: &mut TokenStream);
 }

--- a/gui-core/src/widget.rs
+++ b/gui-core/src/widget.rs
@@ -1,6 +1,26 @@
+use parley::FontContext;
+use proc_macro2::{Ident, TokenStream};
+use std::any::Any;
+use vello::SceneBuilder;
+
 pub trait Widget {
-    type Builder;
+    fn render(&mut self, scene: SceneBuilder, fcx: &mut FontContext);
+}
+
+/// Helper trait to enable trait upcasting, since upcasting is not stable.
+pub trait AsAny: Any {
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl<T: Any> AsAny for T {
+    fn as_any(&self) -> &(dyn Any) {
+        self as &dyn Any
+    }
 }
 
 #[typetag::deserialize(tag = "widget", content = "properties")]
-pub trait WidgetBuilder: std::fmt::Debug {}
+pub trait WidgetBuilder: std::fmt::Debug + AsAny {
+    fn combine(&mut self, rhs: &dyn WidgetBuilder);
+    fn create_widget(&self, stream: &mut TokenStream);
+    fn on_var_update(&self, widget: Ident, var: &str, value: Ident, stream: &mut TokenStream);
+}

--- a/gui-core/src/widget.rs
+++ b/gui-core/src/widget.rs
@@ -20,6 +20,7 @@ impl<T: Any> AsAny for T {
 
 #[typetag::deserialize(tag = "widget", content = "properties")]
 pub trait WidgetBuilder: std::fmt::Debug + AsAny {
+    fn name(&self) -> &'static str;
     fn combine(&mut self, rhs: &dyn WidgetBuilder);
     fn create_widget(&self, stream: &mut TokenStream);
     fn on_var_update(&self, widget: Ident, var: &str, value: Ident, stream: &mut TokenStream);

--- a/gui-derive/Cargo.toml
+++ b/gui-derive/Cargo.toml
@@ -10,3 +10,4 @@ proc-macro = true
 
 
 [dependencies]
+gui-core = { version = "0.1.0", path = "./../gui-core" }

--- a/gui-widget/Cargo.toml
+++ b/gui-widget/Cargo.toml
@@ -6,3 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+gui-core = { version = "0.1.0", path = "./../gui-core" }
+serde_yaml = "0.9.30"
+typetag = "0.2.15"
+serde = { version = "1.0.195", features = ["derive"] }

--- a/gui-widget/src/lib.rs
+++ b/gui-widget/src/lib.rs
@@ -1,5 +1,7 @@
 mod text;
 
+pub use text::Text;
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/gui-widget/src/lib.rs
+++ b/gui-widget/src/lib.rs
@@ -1,14 +1,12 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+mod text;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn parse_simple() {
+        let yaml = include_str!("simple.yaml");
+        let ser: gui_core::parse::GUIDeclaration =
+            serde_yaml::from_str(yaml).expect("TODO: panic message");
+        dbg!(ser);
     }
 }

--- a/gui-widget/src/lib.rs
+++ b/gui-widget/src/lib.rs
@@ -7,8 +7,6 @@ mod tests {
     #[test]
     fn parse_simple() {
         let yaml = include_str!("simple.yaml");
-        let ser: gui_core::parse::GUIDeclaration =
-            serde_yaml::from_str(yaml).expect("TODO: panic message");
-        dbg!(ser);
+        let _ser: gui_core::parse::GUIDeclaration = serde_yaml::from_str(yaml).unwrap();
     }
 }

--- a/gui-widget/src/simple.yaml
+++ b/gui-widget/src/simple.yaml
@@ -1,0 +1,14 @@
+styles:
+  - widget: Text
+    properties:
+      colour: "#ffffff"
+      font: arial
+      size: 12
+
+components:
+  - name: Counter # Names for components must be unique
+    child:
+      name: Count
+      widget: Text
+      properties:
+        text: Hi # Can use any variable from the component

--- a/gui-widget/src/simple.yaml
+++ b/gui-widget/src/simple.yaml
@@ -2,7 +2,6 @@ styles:
   - widget: Text
     properties:
       colour: "#ffffff"
-      font: arial
       size: 12
 
 components:

--- a/gui-widget/src/text.rs
+++ b/gui-widget/src/text.rs
@@ -1,6 +1,48 @@
-use gui_core::widget::WidgetBuilder;
-use gui_core::{Colour, Var};
+use gui_core::common::text;
+use gui_core::common::text::ParleyBrush;
+use gui_core::parley::layout::Layout;
+use gui_core::parley::style::StyleProperty;
+use gui_core::parley::{layout, LayoutContext};
+use gui_core::vello::kurbo::Affine;
+use gui_core::vello::peniko::{Brush, Color};
+use gui_core::widget::{Widget, WidgetBuilder};
+use gui_core::{Colour, FontContext, SceneBuilder, Var};
+use proc_macro2::{Ident, TokenStream};
+use quote::{quote, ToTokens};
 use serde::Deserialize;
+
+pub struct Text {
+    text: String,
+    layout: Option<Layout<ParleyBrush>>,
+}
+
+impl Text {
+    pub fn new(text: String) -> Self {
+        Text { text, layout: None }
+    }
+
+    fn build(&mut self, fcx: &mut FontContext) {
+        let mut lcx = LayoutContext::new();
+        let mut layout_builder = lcx.ranged_builder(fcx, &self.text, 1.0);
+        layout_builder.push_default(&StyleProperty::FontSize(12.0));
+        layout_builder.push_default(&StyleProperty::Brush(ParleyBrush(Brush::Solid(
+            Color::rgb8(255, 255, 255),
+        ))));
+        self.layout = Some(layout_builder.build());
+    }
+}
+
+impl Widget for Text {
+    fn render(&mut self, mut scene: SceneBuilder, fcx: &mut FontContext) {
+        if self.layout.is_none() {
+            self.build(fcx);
+        }
+
+        let layout = self.layout.as_mut().unwrap();
+        layout.break_all_lines(None, layout::Alignment::Start);
+        text::render_text(&mut scene, Affine::translate((0.0, 0.0)), layout);
+    }
+}
 
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
@@ -8,8 +50,42 @@ pub struct TextBuilder {
     pub text: Option<Var<String>>,
     pub colour: Option<Var<Colour>>,
     pub font: Option<Var<String>>,
-    pub size: Option<Var<u32>>,
+    pub size: Option<Var<f32>>,
 }
 
 #[typetag::deserialize(name = "Text")]
-impl WidgetBuilder for TextBuilder {}
+impl WidgetBuilder for TextBuilder {
+    fn combine(&mut self, rhs: &dyn WidgetBuilder) {
+        if let Some(other) = rhs.as_any().downcast_ref::<Self>() {
+            if let Some(s) = &other.text {
+                self.text.get_or_insert_with(|| s.clone());
+            }
+            if let Some(s) = &other.colour {
+                self.colour.get_or_insert_with(|| s.clone());
+            }
+            if let Some(s) = &other.font {
+                self.font.get_or_insert_with(|| s.clone());
+            }
+            if let Some(s) = &other.size {
+                self.size.get_or_insert_with(|| s.clone());
+            }
+        }
+    }
+
+    fn create_widget(&self, stream: &mut TokenStream) {
+        let text = match &self.text {
+            Some(Var::Value(v)) => v.to_token_stream(),
+            _ => "".to_token_stream(),
+        };
+
+        stream.extend(quote! {
+            ::gui_widget::Text::new(String::from(#text))
+        });
+    }
+    fn on_var_update(&self, widget: Ident, var: &str, value: Ident, stream: &mut TokenStream) {
+        match &self.text {
+            Some(Var::Variable(v)) if v == var => stream.extend(quote! {#widget::set_text(#value)}),
+            _ => {}
+        }
+    }
+}

--- a/gui-widget/src/text.rs
+++ b/gui-widget/src/text.rs
@@ -1,0 +1,15 @@
+use gui_core::widget::WidgetBuilder;
+use gui_core::{Colour, Var};
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct TextBuilder {
+    pub text: Option<Var<String>>,
+    pub colour: Option<Var<Colour>>,
+    pub font: Option<Var<String>>,
+    pub size: Option<Var<u32>>,
+}
+
+#[typetag::deserialize(name = "Text")]
+impl WidgetBuilder for TextBuilder {}

--- a/gui-widget/src/text.rs
+++ b/gui-widget/src/text.rs
@@ -37,11 +37,21 @@ impl Text {
         ))));
         self.layout = Some(layout_builder.build());
     }
+
+    pub fn set_text(&mut self, text: String) {
+        if self.text != text {
+            self.text = text;
+            self.layout = None;
+        }
+    }
 }
 
 impl Widget for Text {
     fn render(&mut self, mut scene: SceneBuilder, fcx: &mut FontContext) {
         if self.layout.is_none() {
+            if self.text.is_empty() {
+                return;
+            }
             self.build(fcx);
         }
 
@@ -96,9 +106,9 @@ impl WidgetBuilder for TextBuilder {
             ::gui_widget::Text::new(String::from(#text), #colour, #size)
         });
     }
-    fn on_var_update(&self, widget: Ident, var: &str, value: Ident, stream: &mut TokenStream) {
+    fn on_var_update(&self, widget: &Ident, var: &str, value: &Ident, stream: &mut TokenStream) {
         match &self.text {
-            Some(Var::Variable(v)) if v == var => stream.extend(quote! {#widget::set_text(#value)}),
+            Some(Var::Variable(v)) if v == var => stream.extend(quote! {#widget.set_text(#value)}),
             _ => {}
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,187 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
+use gui_core::glazier::kurbo::Size;
+use gui_core::glazier::{
+    Application, FileDialogToken, FileInfo, IdleToken, KeyEvent, PointerEvent, Region, Scalable,
+    TimerToken, WinHandler, WindowBuilder, WindowHandle,
+};
+use gui_core::vello::peniko::Color;
+use gui_core::vello::util::{RenderContext, RenderSurface};
+use gui_core::vello::{RenderParams, Renderer, RendererOptions, Scene};
+use gui_core::widget::Widget;
+use gui_core::{FontContext, SceneBuilder};
+use std::any::Any;
+use tracing_subscriber::EnvFilter;
+
+const WIDTH: usize = 2048;
+const HEIGHT: usize = 1536;
+
+pub fn run<W: Widget + 'static>(widget: W) {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+    let app = Application::new().unwrap();
+    let window = WindowBuilder::new(app.clone())
+        .size((WIDTH as f64 / 2., HEIGHT as f64 / 2.).into())
+        .handler(Box::new(WindowState::new(widget)))
+        .build()
+        .unwrap();
+    window.show();
+    app.run(None);
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+struct WindowState<W: Widget + 'static> {
+    handle: WindowHandle,
+    renderer: Option<Renderer>,
+    render: RenderContext,
+    surface: Option<RenderSurface>,
+    scene: Scene,
+    size: Size,
+    font_context: FontContext,
+    widget: W,
+}
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+impl<W: Widget> WindowState<W> {
+    pub fn new(widget: W) -> Self {
+        let render = RenderContext::new().unwrap();
+        Self {
+            handle: Default::default(),
+            surface: None,
+            renderer: None,
+            render,
+            scene: Default::default(),
+            font_context: FontContext::new(),
+            widget,
+            size: Size::new(800.0, 600.0),
+        }
+    }
+
+    fn schedule_render(&self) {
+        self.handle.invalidate();
+    }
+
+    fn surface_size(&self) -> (u32, u32) {
+        let handle = &self.handle;
+        let scale = handle.get_scale().unwrap_or_default();
+        let insets = handle.content_insets().to_px(scale);
+        let mut size = handle.get_size().to_px(scale);
+        size.width -= insets.x_value();
+        size.height -= insets.y_value();
+        (size.width as u32, size.height as u32)
+    }
+
+    fn render(&mut self) {
+        let (width, height) = self.surface_size();
+        if self.surface.is_none() {
+            self.surface = Some(
+                pollster::block_on(self.render.create_surface(&self.handle, width, height))
+                    .expect("failed to create surface"),
+            );
+        }
+
+        let sb = SceneBuilder::for_scene(&mut self.scene);
+        self.widget.render(sb, &mut self.font_context);
+
+        if let Some(surface) = self.surface.as_mut() {
+            if surface.config.width != width || surface.config.height != height {
+                self.render.resize_surface(surface, width, height);
+            }
+            let surface_texture = surface.surface.get_current_texture().unwrap();
+            let dev_id = surface.dev_id;
+            let device = &self.render.devices[dev_id].device;
+            let queue = &self.render.devices[dev_id].queue;
+            let renderer_options = RendererOptions {
+                surface_format: Some(surface.format),
+                timestamp_period: queue.get_timestamp_period(),
+            };
+            let render_params = RenderParams {
+                base_color: Color::BLACK,
+                width,
+                height,
+            };
+            self.renderer
+                .get_or_insert_with(|| Renderer::new(device, &renderer_options).unwrap())
+                .render_to_surface(device, queue, &self.scene, &surface_texture, &render_params)
+                .unwrap();
+            surface_texture.present();
+        }
+    }
+}
+
+impl<W: Widget + 'static> WinHandler for WindowState<W> {
+    fn connect(&mut self, handle: &WindowHandle) {
+        self.handle = handle.clone();
+        self.schedule_render();
+    }
+
+    fn size(&mut self, size: Size) {
+        self.size = size;
+    }
+
+    fn prepare_paint(&mut self) {}
+
+    fn paint(&mut self, _: &Region) {
+        self.render();
+        self.schedule_render();
+    }
+
+    fn command(&mut self, _id: u32) {}
+
+    fn save_as(&mut self, _token: FileDialogToken, file: Option<FileInfo>) {
+        println!("save file result: {file:?}");
+    }
+
+    fn open_file(&mut self, _token: FileDialogToken, file_info: Option<FileInfo>) {
+        println!("open file result: {file_info:?}");
+    }
+
+    fn key_down(&mut self, event: &KeyEvent) -> bool {
+        println!("keydown: {event:?}");
+        false
+    }
+
+    fn key_up(&mut self, event: &KeyEvent) {
+        println!("keyup: {event:?}");
+    }
+
+    fn wheel(&mut self, event: &PointerEvent) {
+        println!("wheel {event:?}");
+    }
+
+    fn pointer_move(&mut self, event: &PointerEvent) {
+        // self.handle.set_cursor(&Cursor::Arrow);
+        println!("pointer_move {event:?}");
+    }
+
+    fn pointer_down(&mut self, event: &PointerEvent) {
+        println!("pointer_down {event:?}");
+    }
+
+    fn pointer_up(&mut self, event: &PointerEvent) {
+        println!("pointer_up {event:?}");
+    }
+
+    fn timer(&mut self, id: TimerToken) {
+        println!("timer fired: {id:?}");
+    }
+
+    fn got_focus(&mut self) {
+        println!("Got focus");
+    }
+
+    fn lost_focus(&mut self) {
+        println!("Lost focus");
+    }
+
+    fn request_close(&mut self) {
+        self.handle.close();
+    }
+
+    fn destroy(&mut self) {
+        Application::global().quit();
+    }
+
+    fn idle(&mut self, _: IdleToken) {}
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ use gui_core::{FontContext, SceneBuilder};
 use std::any::Any;
 use tracing_subscriber::EnvFilter;
 
+pub use gui_core;
+
 const WIDTH: usize = 2048;
 const HEIGHT: usize = 1536;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-pub use glazier;
-pub use parley;
-pub use vello;
-
 pub fn add(left: usize, right: usize) -> usize {
     left + right
 }


### PR DESCRIPTION
- Utilise `typetag` for widgets thus no longer needing the widget to be registered using the framework (just need extern crate)
- Update Update like so 
```rs
impl Update<gen::test> for Counter {
    fn is_updated(&self) -> bool {
        true
    }
    fn value(&self) -> String {
        Alphanumeric.sample_string(&mut rand::thread_rng(), 16)
    }
}
``` 
Instead of 
```rs
impl Update for gen::test {
	type Value = String;
    fn is_updated(&self) -> bool {
        true
    }
    fn value(&self) -> String {
        Alphanumeric.sample_string(&mut rand::thread_rng(), 16)
    }
}
```
 which required derefing and thus required a lifetime bound on `gen::test` 
- Added `gui_build` as a dependency that can be added in build dependencies