### PR TITLE
Add layout positioning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ pollster = "0.3.0"
 fluent-bundle = { version = "0.15.2", git = "https://github.com/projectfluent/fluent-rs.git", rev = "a2cef6bff4885623f638a6968e034ce1a296ba01" }
 unic-langid = { version = "0.9.4", features = ["unic-langid-macros"] }
 intl-memoizer = "0.5.1"
+wgpu-types = "0.17.0"

--- a/examples/testbed/simple.yaml
+++ b/examples/testbed/simple.yaml
@@ -8,14 +8,10 @@ components:
     variables:
       - name: count
         type: f32
-      - name: disabled
-        type: bool
     child:
       name: Count
       widget: Button
       properties:
-        disabled:
-          variable: disabled
         child:
           widget: Text
           properties:
@@ -25,3 +21,5 @@ components:
                   [1] 1 apple
                  *[other] {$count} apples
               }
+            size:
+              variable: count

--- a/examples/testbed/src/main.rs
+++ b/examples/testbed/src/main.rs
@@ -1,4 +1,3 @@
-use crate::gen::count;
 use gui::gui_widget::button::ButtonHandler;
 use gui::{ToComponent, Updateable};
 

--- a/examples/testbed/src/main.rs
+++ b/examples/testbed/src/main.rs
@@ -16,7 +16,7 @@ impl Default for Counter {
 
 impl ButtonHandler<gen::Count> for Counter {
     fn on_press(&mut self) {
-        *self.count.invalidate() += 5.0;
+        *self.count.invalidate() += 1.0;
     }
 }
 fn main() {

--- a/examples/testbed/src/main.rs
+++ b/examples/testbed/src/main.rs
@@ -1,24 +1,23 @@
+use crate::gen::count;
 use gui::gui_widget::button::ButtonHandler;
-use gui::{ToComponent, Update, Updateable};
+use gui::{ToComponent, Updateable};
 
-#[derive(ToComponent, Default)]
+#[derive(ToComponent)]
 struct Counter {
     count: Updateable<f32>,
 }
 
-impl Update<gen::disabled> for Counter {
-    fn is_updated(&self) -> bool {
-        self.count.is_updated()
-    }
-
-    fn value(&self) -> bool {
-        self.count.value() > 0.0
+impl Default for Counter {
+    fn default() -> Self {
+        Self {
+            count: Updateable::new(12.0),
+        }
     }
 }
 
 impl ButtonHandler<gen::Count> for Counter {
     fn on_press(&mut self) {
-        *self.count.invalidate() += 1.0;
+        *self.count.invalidate() += 5.0;
     }
 }
 fn main() {

--- a/gui-build/Cargo.toml
+++ b/gui-build/Cargo.toml
@@ -5,6 +5,11 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+
+[features]
+pretty = ["dep:prettyplease", "dep:syn"]
+default = ["pretty"]
+
 [dependencies]
 gui-core = { version = "0.1.0", path = "./../gui-core" }
 serde_yaml = "0.9.30"
@@ -15,3 +20,5 @@ unic-langid = "0.9.4"
 fluent-bundle = "0.15.2"
 gui-widget = {path = "./../gui-widget"}
 itertools = "0.12.0"
+prettyplease = { version = "0.2.16", optional = true }
+syn = { version = "2.0.48", optional = true, features = ["full"] }

--- a/gui-build/src/component.rs
+++ b/gui-build/src/component.rs
@@ -87,7 +87,7 @@ pub fn create_component(out_dir: &Path, component: &ComponentDeclaration) -> any
             use gui::gui_core::parley::font::FontContext;
             use gui::gui_core::vello::SceneBuilder;
             use gui::gui_core::widget::Widget;
-            use gui::gui_core::{Component, LayoutConstraints, Size, ToComponent, ToHandler, Update, Variable};
+            use gui::gui_core::{Component, LayoutConstraints, Size, Point, ToComponent, ToHandler, Update, Variable};
 
             #bundle_func
 
@@ -132,16 +132,16 @@ pub fn create_component(out_dir: &Path, component: &ComponentDeclaration) -> any
                     self.widget.resize(constraints, fcx)
                 }
 
-                fn pointer_down(&mut self, event: &PointerEvent, window: &WindowHandle) {
-                    self.widget.pointer_down(event, window, &mut self.comp_struct);
+                fn pointer_down(&mut self, local_pos: Point, event: &PointerEvent, window: &WindowHandle) {
+                    self.widget.pointer_down(local_pos, event, window, &mut self.comp_struct);
                 }
 
-                fn pointer_up(&mut self, event: &PointerEvent, window: &WindowHandle) {
-                    self.widget.pointer_up(event, window, &mut self.comp_struct);
+                fn pointer_up(&mut self, local_pos: Point, event: &PointerEvent, window: &WindowHandle) {
+                    self.widget.pointer_up(local_pos, event, window, &mut self.comp_struct);
                 }
 
-                fn pointer_move(&mut self, event: &PointerEvent, window: &WindowHandle) {
-                    self.widget.pointer_move(event, window, &mut self.comp_struct);
+                fn pointer_move(&mut self, local_pos: Point, event: &PointerEvent, window: &WindowHandle) {
+                    self.widget.pointer_move(local_pos, event, window, &mut self.comp_struct);
                 }
             }
         }

--- a/gui-build/src/component.rs
+++ b/gui-build/src/component.rs
@@ -87,7 +87,7 @@ pub fn create_component(out_dir: &Path, component: &ComponentDeclaration) -> any
             use gui::gui_core::parley::font::FontContext;
             use gui::gui_core::vello::SceneBuilder;
             use gui::gui_core::widget::Widget;
-            use gui::gui_core::{Component, ToComponent, ToHandler, Update, Variable};
+            use gui::gui_core::{Component, LayoutConstraints, Size, ToComponent, ToHandler, Update, Variable};
 
             #bundle_func
 
@@ -128,6 +128,10 @@ pub fn create_component(out_dir: &Path, component: &ComponentDeclaration) -> any
                     #( <CompStruct as Update<#var_names>>::reset(&mut self.comp_struct); )*
                 }
 
+                fn resize(&mut self, constraints: LayoutConstraints, fcx: &mut FontContext) -> Size{
+                    self.widget.resize(constraints, fcx)
+                }
+
                 fn pointer_down(&mut self, event: &PointerEvent, window: &WindowHandle) {
                     self.widget.pointer_down(event, window, &mut self.comp_struct);
                 }
@@ -143,8 +147,19 @@ pub fn create_component(out_dir: &Path, component: &ComponentDeclaration) -> any
         }
     };
 
-    fs::write(rs_path, format!("{}", gen_module))?;
+    write_file(&rs_path, gen_module)
+}
 
+#[cfg(not(feature = "pretty"))]
+fn write_file(path: &Path, stream: TokenStream) -> anyhow::Result<()> {
+    fs::write(path, format!("{}", stream))?;
+    Ok(())
+}
+#[cfg(feature = "pretty")]
+fn write_file(path: &Path, stream: TokenStream) -> anyhow::Result<()> {
+    let file = syn::parse2::<syn::File>(stream)?;
+
+    fs::write(path, prettyplease::unparse(&file))?;
     Ok(())
 }
 

--- a/gui-core/src/layout.rs
+++ b/gui-core/src/layout.rs
@@ -60,11 +60,14 @@ impl LayoutConstraints {
     pub fn min_clamp(&self, min: Size) -> LayoutConstraints {
         LayoutConstraints::new(
             self.min.clamp(min, Size::new(f64::INFINITY, f64::INFINITY)),
-            self.max,
+            self.max.clamp(min, Size::new(f64::INFINITY, f64::INFINITY)),
         )
     }
 
     pub fn max_clamp(&self, max: Size) -> LayoutConstraints {
-        LayoutConstraints::new(self.min, self.max.clamp(Size::new(0.0, 0.0), max))
+        LayoutConstraints::new(
+            self.min.clamp(Size::new(0.0, 0.0), max),
+            self.max.clamp(Size::new(0.0, 0.0), max),
+        )
     }
 }

--- a/gui-core/src/layout.rs
+++ b/gui-core/src/layout.rs
@@ -1,0 +1,70 @@
+use vello::kurbo::common::FloatExt;
+use vello::kurbo::Size;
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[must_use]
+pub struct LayoutConstraints {
+    min: Size,
+    max: Size,
+}
+
+fn expand_safe(val: f64) -> f64 {
+    val.expand().max(0.0)
+}
+
+impl LayoutConstraints {
+    pub const UNBOUNDED: Self = LayoutConstraints {
+        min: Size::ZERO,
+        max: Size::new(f64::INFINITY, f64::INFINITY),
+    };
+
+    pub fn new(min: Size, max: Size) -> LayoutConstraints {
+        assert!(min.width <= max.width, "min width greater than max width");
+        assert!(
+            min.height <= max.height,
+            "min height greater than max height"
+        );
+        LayoutConstraints {
+            min: Size::new(expand_safe(min.width), expand_safe(min.height)),
+            max: Size::new(expand_safe(max.width), expand_safe(max.height)),
+        }
+    }
+
+    pub fn new_max(max: Size) -> LayoutConstraints {
+        LayoutConstraints::new(Size::ZERO, max)
+    }
+
+    pub fn tight(size: Size) -> LayoutConstraints {
+        LayoutConstraints::new(size, size)
+    }
+
+    pub fn get_min(&self) -> Size {
+        self.min
+    }
+    pub fn get_max(&self) -> Size {
+        self.max
+    }
+
+    pub fn deset(&self, size: Size) -> LayoutConstraints {
+        LayoutConstraints::new(self.min - size * 2.0, self.max - size * 2.0)
+    }
+
+    pub fn inset(&self, size: Size) -> LayoutConstraints {
+        LayoutConstraints::new(self.min + size * 2.0, self.max + size * 2.0)
+    }
+
+    pub fn max_advance(&self) -> Option<f32> {
+        self.max.width.is_finite().then_some(self.max.width as f32)
+    }
+
+    pub fn min_clamp(&self, min: Size) -> LayoutConstraints {
+        LayoutConstraints::new(
+            self.min.clamp(min, Size::new(f64::INFINITY, f64::INFINITY)),
+            self.max,
+        )
+    }
+
+    pub fn max_clamp(&self, max: Size) -> LayoutConstraints {
+        LayoutConstraints::new(self.min, self.max.clamp(Size::new(0.0, 0.0), max))
+    }
+}

--- a/gui-core/src/lib.rs
+++ b/gui-core/src/lib.rs
@@ -2,8 +2,12 @@ pub mod common;
 pub mod parse;
 pub mod widget;
 
+pub mod layout;
+
+pub use layout::LayoutConstraints;
 pub use parse::colour::Colour;
 pub use parse::var::Var;
+pub use vello::kurbo::Size;
 
 pub use glazier;
 use glazier::{PointerEvent, WindowHandle};
@@ -21,6 +25,7 @@ struct TestBoxable {
 pub trait Component {
     fn render(&mut self, scene: SceneBuilder, fcx: &mut FontContext);
     fn update_vars(&mut self, force_update: bool);
+    fn resize(&mut self, constraints: LayoutConstraints, fcx: &mut FontContext) -> Size;
     fn pointer_down(&mut self, event: &PointerEvent, window: &WindowHandle);
     fn pointer_up(&mut self, event: &PointerEvent, window: &WindowHandle);
     fn pointer_move(&mut self, event: &PointerEvent, window: &WindowHandle);

--- a/gui-core/src/lib.rs
+++ b/gui-core/src/lib.rs
@@ -10,6 +10,7 @@ pub use parse::var::Var;
 pub use vello::kurbo::Size;
 
 pub use glazier;
+pub use glazier::kurbo::Point;
 use glazier::{PointerEvent, WindowHandle};
 pub use parley;
 pub use vello;
@@ -26,9 +27,9 @@ pub trait Component {
     fn render(&mut self, scene: SceneBuilder, fcx: &mut FontContext);
     fn update_vars(&mut self, force_update: bool);
     fn resize(&mut self, constraints: LayoutConstraints, fcx: &mut FontContext) -> Size;
-    fn pointer_down(&mut self, event: &PointerEvent, window: &WindowHandle);
-    fn pointer_up(&mut self, event: &PointerEvent, window: &WindowHandle);
-    fn pointer_move(&mut self, event: &PointerEvent, window: &WindowHandle);
+    fn pointer_down(&mut self, local_pos: Point, event: &PointerEvent, window: &WindowHandle);
+    fn pointer_up(&mut self, local_pos: Point, event: &PointerEvent, window: &WindowHandle);
+    fn pointer_move(&mut self, local_pos: Point, event: &PointerEvent, window: &WindowHandle);
 }
 
 pub trait ToComponent {

--- a/gui-core/src/widget.rs
+++ b/gui-core/src/widget.rs
@@ -1,6 +1,7 @@
 use crate::layout::LayoutConstraints;
 use crate::parse::fluent::Fluent;
 use crate::parse::WidgetDeclaration;
+use crate::Point;
 use dyn_clone::DynClone;
 use glazier::{PointerEvent, WindowHandle};
 use parley::FontContext;
@@ -12,9 +13,30 @@ use vello::SceneBuilder;
 pub trait Widget<H> {
     fn render(&mut self, scene: &mut SceneBuilder, fcx: &mut FontContext);
     fn resize(&mut self, constraints: LayoutConstraints, fcx: &mut FontContext) -> Size;
-    fn pointer_down(&mut self, _event: &PointerEvent, _window: &WindowHandle, _handler: &mut H) {}
-    fn pointer_up(&mut self, _event: &PointerEvent, _window: &WindowHandle, _handler: &mut H) {}
-    fn pointer_move(&mut self, _event: &PointerEvent, _window: &WindowHandle, _handler: &mut H) {}
+    fn pointer_down(
+        &mut self,
+        _local_pos: Point,
+        _event: &PointerEvent,
+        _window: &WindowHandle,
+        _handler: &mut H,
+    ) {
+    }
+    fn pointer_up(
+        &mut self,
+        _local_pos: Point,
+        _event: &PointerEvent,
+        _window: &WindowHandle,
+        _handler: &mut H,
+    ) {
+    }
+    fn pointer_move(
+        &mut self,
+        _local_pos: Point,
+        _event: &PointerEvent,
+        _window: &WindowHandle,
+        _handler: &mut H,
+    ) {
+    }
 }
 
 /// Helper trait to enable trait upcasting, since upcasting is not stable.

--- a/gui-core/src/widget.rs
+++ b/gui-core/src/widget.rs
@@ -1,3 +1,4 @@
+use crate::layout::LayoutConstraints;
 use crate::parse::fluent::Fluent;
 use crate::parse::WidgetDeclaration;
 use dyn_clone::DynClone;
@@ -5,10 +6,12 @@ use glazier::{PointerEvent, WindowHandle};
 use parley::FontContext;
 use proc_macro2::{Ident, TokenStream};
 use std::any::Any;
+use vello::kurbo::Size;
 use vello::SceneBuilder;
 
 pub trait Widget<H> {
     fn render(&mut self, scene: &mut SceneBuilder, fcx: &mut FontContext);
+    fn resize(&mut self, constraints: LayoutConstraints, fcx: &mut FontContext) -> Size;
     fn pointer_down(&mut self, _event: &PointerEvent, _window: &WindowHandle, _handler: &mut H) {}
     fn pointer_up(&mut self, _event: &PointerEvent, _window: &WindowHandle, _handler: &mut H) {}
     fn pointer_move(&mut self, _event: &PointerEvent, _window: &WindowHandle, _handler: &mut H) {}

--- a/gui-widget/src/button.rs
+++ b/gui-widget/src/button.rs
@@ -7,7 +7,7 @@ use gui_core::vello::kurbo::{Affine, Rect, Vec2};
 use gui_core::vello::peniko::{BlendMode, Brush, Color, Compose, Fill, Mix, Stroke};
 use gui_core::vello::SceneFragment;
 use gui_core::widget::{Widget, WidgetBuilder};
-use gui_core::{Colour, FontContext, SceneBuilder, ToHandler, Var};
+use gui_core::{Colour, FontContext, Point, SceneBuilder, ToHandler, Var};
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, ToTokens};
 use serde::Deserialize;
@@ -161,14 +161,26 @@ impl<T: ToHandler<BaseHandler = H>, H: ButtonHandler<T>, W: Widget<H>> Widget<H>
         child_size
     }
 
-    fn pointer_down(&mut self, event: &PointerEvent, _window: &WindowHandle, _handler: &mut H) {
+    fn pointer_down(
+        &mut self,
+        local_pos: Point,
+        _event: &PointerEvent,
+        _window: &WindowHandle,
+        _handler: &mut H,
+    ) {
         if self.disabled {
             return;
         }
-        self.clicking = self.size.to_rounded_rect(4.0).contains(event.pos);
+        self.clicking = self.size.to_rounded_rect(4.0).contains(local_pos);
     }
 
-    fn pointer_up(&mut self, _event: &PointerEvent, _window: &WindowHandle, handler: &mut H) {
+    fn pointer_up(
+        &mut self,
+        _local_pos: Point,
+        _event: &PointerEvent,
+        _window: &WindowHandle,
+        handler: &mut H,
+    ) {
         if self.disabled {
             return;
         }
@@ -178,11 +190,17 @@ impl<T: ToHandler<BaseHandler = H>, H: ButtonHandler<T>, W: Widget<H>> Widget<H>
         }
     }
 
-    fn pointer_move(&mut self, event: &PointerEvent, _window: &WindowHandle, _handler: &mut H) {
+    fn pointer_move(
+        &mut self,
+        local_pos: Point,
+        _event: &PointerEvent,
+        _window: &WindowHandle,
+        _handler: &mut H,
+    ) {
         if self.disabled {
             return;
         }
-        self.hovered = self.size.to_rounded_rect(4.0).contains(event.pos);
+        self.hovered = self.size.to_rounded_rect(4.0).contains(local_pos);
     }
 }
 

--- a/gui-widget/src/button.rs
+++ b/gui-widget/src/button.rs
@@ -1,5 +1,6 @@
-use gui_core::glazier::kurbo::Shape;
+use gui_core::glazier::kurbo::{Shape, Size};
 use gui_core::glazier::{PointerEvent, WindowHandle};
+use gui_core::layout::LayoutConstraints;
 use gui_core::parse::fluent::Fluent;
 use gui_core::parse::WidgetDeclaration;
 use gui_core::vello::kurbo::{Affine, Rect, Vec2};
@@ -51,7 +52,7 @@ impl<T: ToHandler<BaseHandler = H>, H: ButtonHandler<T>, W: Widget<H>> Button<T,
             hover_colour,
             border_colour,
             disabled,
-            size: Rect::new(0.0, 0.0, 150.0, 40.0),
+            size: Rect::new(0.0, 0.0, 0.0, 0.0),
             hovered: false,
             clicking: false,
             child,
@@ -82,11 +83,12 @@ impl<T: ToHandler<BaseHandler = H>, H: ButtonHandler<T>, W: Widget<H>> Button<T,
     }
 }
 
+const STOKE_WIDTH: f64 = 0.58;
+
 impl<T: ToHandler<BaseHandler = H>, H: ButtonHandler<T>, W: Widget<H>> Widget<H>
     for Button<T, H, W>
 {
     fn render(&mut self, scene: &mut SceneBuilder, fcx: &mut FontContext) {
-        let stroke_width = 0.58_f32;
         let affine = if self.clicking {
             Affine::translate(Vec2::new(0.0, 0.875))
         } else {
@@ -101,10 +103,7 @@ impl<T: ToHandler<BaseHandler = H>, H: ButtonHandler<T>, W: Widget<H>> Widget<H>
         } else {
             self.background_colour
         };
-        let rect = self
-            .size
-            .inset(-0.5 * stroke_width as f64)
-            .to_rounded_rect(4.0);
+        let rect = self.size.inset(-0.5 * STOKE_WIDTH).to_rounded_rect(4.0);
         scene.fill(
             Fill::NonZero,
             affine,
@@ -119,8 +118,8 @@ impl<T: ToHandler<BaseHandler = H>, H: ButtonHandler<T>, W: Widget<H>> Widget<H>
         scene.append(
             &fragment,
             Some(Affine::translate(Vec2::new(
-                stroke_width as f64 + 18.0,
-                stroke_width as f64 + if self.clicking { 0.875 } else { 0.0 },
+                STOKE_WIDTH + 18.0,
+                STOKE_WIDTH + if self.clicking { 0.875 } else { 0.0 },
             ))),
         );
         if self.disabled {
@@ -142,13 +141,24 @@ impl<T: ToHandler<BaseHandler = H>, H: ButtonHandler<T>, W: Widget<H>> Widget<H>
             scene.pop_layer()
         } else {
             scene.stroke(
-                &Stroke::new(stroke_width),
+                &Stroke::new(STOKE_WIDTH as f32),
                 affine,
                 &Brush::Solid(self.border_colour.0),
                 None,
                 &self.size.to_rounded_rect(4.5),
             );
         }
+    }
+
+    fn resize(&mut self, mut constraints: LayoutConstraints, fcx: &mut FontContext) -> Size {
+        let padding = Size::new(STOKE_WIDTH + 18.0, STOKE_WIDTH);
+        constraints = constraints.deset(padding);
+        let mut child_size = self
+            .child
+            .resize(constraints.min_clamp(Size::new(0.0, 18.0)), fcx);
+        child_size += padding * 2.0;
+        self.size = child_size.to_rect();
+        child_size
     }
 
     fn pointer_down(&mut self, event: &PointerEvent, _window: &WindowHandle, _handler: &mut H) {

--- a/gui-widget/src/text.rs
+++ b/gui-widget/src/text.rs
@@ -1,8 +1,10 @@
 use gui_core::common::text;
 use gui_core::common::text::ParleyBrush;
-use gui_core::parley::layout::Layout;
+use gui_core::glazier::kurbo::Size;
+use gui_core::layout::LayoutConstraints;
+use gui_core::parley::layout::{Alignment, Layout};
 use gui_core::parley::style::{FontWeight, StyleProperty};
-use gui_core::parley::{layout, LayoutContext};
+use gui_core::parley::LayoutContext;
 use gui_core::parse::fluent::Fluent;
 use gui_core::parse::WidgetDeclaration;
 use gui_core::vello::kurbo::Affine;
@@ -74,8 +76,19 @@ impl<T> Widget<T> for Text {
         }
 
         let layout = self.layout.as_mut().unwrap();
-        layout.break_all_lines(None, layout::Alignment::Start);
         text::render_text(scene, Affine::translate((0.0, 0.0)), layout);
+    }
+
+    fn resize(&mut self, constraints: LayoutConstraints, fcx: &mut FontContext) -> Size {
+        if self.layout.is_none() {
+            if self.text.is_empty() {
+                return Size::ZERO;
+            }
+            self.build(fcx);
+        }
+        let layout = self.layout.as_mut().unwrap();
+        layout.break_all_lines(constraints.max_advance(), Alignment::Start);
+        Size::new(layout.width() as f64, layout.height() as f64)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use gui_core::glazier::{
 use gui_core::vello::peniko::Color;
 use gui_core::vello::util::{RenderContext, RenderSurface};
 use gui_core::vello::{RenderParams, Renderer, RendererOptions, Scene, SceneFragment};
-use gui_core::{Component, FontContext, SceneBuilder, ToComponent};
+use gui_core::{Component, FontContext, Point, SceneBuilder, ToComponent};
 use std::any::Any;
 use tracing_subscriber::EnvFilter;
 
@@ -88,6 +88,10 @@ impl<C: Component> WindowState<C> {
             (max_width as f64 - size.width) / 2.0,
             (max_height as f64 - size.height) / 2.0,
         );
+    }
+
+    fn get_local_point(&self, event: &PointerEvent) -> Point {
+        (event.pos.to_vec2() - self.transform).to_point()
     }
 
     fn surface_size(&self) -> (u32, u32) {
@@ -189,17 +193,20 @@ impl<C: Component + 'static> WinHandler for WindowState<C> {
     }
 
     fn pointer_move(&mut self, event: &PointerEvent) {
-        self.component.pointer_move(event, &self.handle);
+        self.component
+            .pointer_move(self.get_local_point(event), event, &self.handle);
         self.component.update_vars(false);
     }
 
     fn pointer_down(&mut self, event: &PointerEvent) {
-        self.component.pointer_down(event, &self.handle);
+        self.component
+            .pointer_down(self.get_local_point(event), event, &self.handle);
         self.component.update_vars(false);
     }
 
     fn pointer_up(&mut self, event: &PointerEvent) {
-        self.component.pointer_up(event, &self.handle);
+        self.component
+            .pointer_up(self.get_local_point(event), event, &self.handle);
         self.component.update_vars(false);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,7 @@ impl<C: Component> WindowState<C> {
                 .render_to_surface(device, queue, &self.scene, &surface_texture, &render_params)
                 .unwrap();
             surface_texture.present();
+            device.poll(wgpu_types::Maintain::Wait);
         }
     }
 }


### PR DESCRIPTION
- Updated to use a pretty printer when generating rust files.
- Fixes timeout errors that were happening when my gpu was too slow.
- Add layout contraints to give the min and max size
- Experimented with setting a min size for the window handle but glazier doesn't support it and setting the size every frame made it very laggy.