### PR TITLE
Create new event handler architecture

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ fluent-bundle = { version = "0.15.2", git = "https://github.com/projectfluent/fl
 unic-langid = { version = "0.9.4", features = ["unic-langid-macros"] }
 intl-memoizer = "0.5.1"
 wgpu-types = "0.17.0"
+itertools = "0.12.0"

--- a/examples/testbed/simple.yaml
+++ b/examples/testbed/simple.yaml
@@ -1,4 +1,7 @@
 styles:
+  - widget: Text
+    properties:
+      size: 40
 components:
   - name: Counter # Names for components must be unique
     variables:
@@ -12,6 +15,7 @@ components:
         # so that custom widgets do not need to deal with layout.
         padding: 10
       properties:
+        spacing: 40
         children:
           - name: Count
             widget: Text

--- a/examples/testbed/simple.yaml
+++ b/examples/testbed/simple.yaml
@@ -13,6 +13,11 @@ components:
         padding: 10
       properties:
         children:
+          - name: Count
+            widget: Text
+            properties:
+              text: "{$count}" # Can use any variable from the component
+
           - name: IncrementBtn
             widget: Button
             properties:
@@ -21,11 +26,6 @@ components:
                 widget: Text
                 properties:
                   text: Increment # Uses Fluent syntax https://projectfluent.org/
-
-          - name: Count
-            widget: Text
-            properties:
-              text: "{$count}" # Can use any variable from the component
 
           - name: DecrementBtn
             widget: Button

--- a/examples/testbuild/OUT_DIR/Counter.ftl
+++ b/examples/testbuild/OUT_DIR/Counter.ftl
@@ -1,3 +1,3 @@
-Counter-IncrText-text = Increment
 Counter-Count-text = {$count}
+Counter-IncrText-text = Increment
 Counter-DecrText-text = Decrement

--- a/examples/testbuild/OUT_DIR/Counter.ftl
+++ b/examples/testbuild/OUT_DIR/Counter.ftl
@@ -1,2 +1,3 @@
-Counter-Other-text = Hiya
-Counter-Text-text = Testsfa
+Counter-IncrText-text = Increment
+Counter-Count-text = {$count}
+Counter-DecrText-text = Decrement

--- a/examples/testbuild/OUT_DIR/Counter.rs
+++ b/examples/testbuild/OUT_DIR/Counter.rs
@@ -10,21 +10,39 @@ mod gen {
         Variable,
     };
     enum WidgetSet0 {
-        W0(::gui::gui_widget::Text),
-        W1(::gui::gui_widget::Button<Count, CompStruct, ::gui::gui_widget::Text>),
+        W0(::gui::gui_widget::Button<IncrementBtn, CompStruct, ::gui::gui_widget::Text>),
+        W1(::gui::gui_widget::Text),
+        W2(::gui::gui_widget::Button<DecrementBtn, CompStruct, ::gui::gui_widget::Text>),
     }
     impl WidgetSet0 {
-        pub fn w0(&mut self) -> &mut ::gui::gui_widget::Text {
+        pub fn w0(
+            &mut self,
+        ) -> &mut ::gui::gui_widget::Button<
+            IncrementBtn,
+            CompStruct,
+            ::gui::gui_widget::Text,
+        > {
             if let WidgetSet0::W0(val) = self {
                 val
             } else {
                 panic!("Incorrect wrapped type.")
             }
         }
-        pub fn w1(
-            &mut self,
-        ) -> &mut ::gui::gui_widget::Button<Count, CompStruct, ::gui::gui_widget::Text> {
+        pub fn w1(&mut self) -> &mut ::gui::gui_widget::Text {
             if let WidgetSet0::W1(val) = self {
+                val
+            } else {
+                panic!("Incorrect wrapped type.")
+            }
+        }
+        pub fn w2(
+            &mut self,
+        ) -> &mut ::gui::gui_widget::Button<
+            DecrementBtn,
+            CompStruct,
+            ::gui::gui_widget::Text,
+        > {
+            if let WidgetSet0::W2(val) = self {
                 val
             } else {
                 panic!("Incorrect wrapped type.")
@@ -32,111 +50,87 @@ mod gen {
         }
     }
     impl Widget<CompStruct> for WidgetSet0 {
-        fn render(&mut self, scene: &mut SceneBuilder, fcx: &mut FontContext) {
+        fn id(&self) -> WidgetID {
+            match self {
+                WidgetSet0::W0(w) => WidgetID::new(0u32, 1u32),
+                WidgetSet0::W1(w) => WidgetID::new(0u32, 3u32),
+                WidgetSet0::W2(w) => WidgetID::new(0u32, 4u32),
+            }
+        }
+        fn render(
+            &mut self,
+            scene: &mut SceneBuilder,
+            handle: &mut RenderHandle<CompStruct>,
+        ) {
             match self {
                 WidgetSet0::W0(w) => {
-                    <::gui::gui_widget::Text as Widget<
-                        CompStruct,
-                    >>::render(w, scene, fcx)
-                }
-                WidgetSet0::W1(w) => {
                     <::gui::gui_widget::Button<
-                        Count,
+                        IncrementBtn,
                         CompStruct,
                         ::gui::gui_widget::Text,
-                    > as Widget<CompStruct>>::render(w, scene, fcx)
+                    > as Widget<CompStruct>>::render(w, scene, handle)
+                }
+                WidgetSet0::W1(w) => {
+                    <::gui::gui_widget::Text as Widget<
+                        CompStruct,
+                    >>::render(w, scene, handle)
+                }
+                WidgetSet0::W2(w) => {
+                    <::gui::gui_widget::Button<
+                        DecrementBtn,
+                        CompStruct,
+                        ::gui::gui_widget::Text,
+                    > as Widget<CompStruct>>::render(w, scene, handle)
                 }
             }
         }
         fn resize(
             &mut self,
             constraints: LayoutConstraints,
-            fcx: &mut FontContext,
+            handle: &mut ResizeHandle<CompStruct>,
         ) -> Size {
             match self {
                 WidgetSet0::W0(w) => {
-                    <::gui::gui_widget::Text as Widget<
-                        CompStruct,
-                    >>::resize(w, constraints, fcx)
-                }
-                WidgetSet0::W1(w) => {
                     <::gui::gui_widget::Button<
-                        Count,
+                        IncrementBtn,
                         CompStruct,
                         ::gui::gui_widget::Text,
-                    > as Widget<CompStruct>>::resize(w, constraints, fcx)
+                    > as Widget<CompStruct>>::resize(w, constraints, handle)
+                }
+                WidgetSet0::W1(w) => {
+                    <::gui::gui_widget::Text as Widget<
+                        CompStruct,
+                    >>::resize(w, constraints, handle)
+                }
+                WidgetSet0::W2(w) => {
+                    <::gui::gui_widget::Button<
+                        DecrementBtn,
+                        CompStruct,
+                        ::gui::gui_widget::Text,
+                    > as Widget<CompStruct>>::resize(w, constraints, handle)
                 }
             }
         }
-        fn pointer_down(
-            &mut self,
-            local_pos: Point,
-            event: &PointerEvent,
-            window: &WindowHandle,
-            handler: &mut CompStruct,
-        ) {
+        fn event(&mut self, event: WidgetEvent, handle: &mut EventHandle<CompStruct>) {
             match self {
                 WidgetSet0::W0(w) => {
-                    <::gui::gui_widget::Text as Widget<
-                        CompStruct,
-                    >>::pointer_down(w, local_pos, event, window, handler)
-                }
-                WidgetSet0::W1(w) => {
                     <::gui::gui_widget::Button<
-                        Count,
+                        IncrementBtn,
                         CompStruct,
                         ::gui::gui_widget::Text,
-                    > as Widget<
-                        CompStruct,
-                    >>::pointer_down(w, local_pos, event, window, handler)
-                }
-            }
-        }
-        fn pointer_up(
-            &mut self,
-            local_pos: Point,
-            event: &PointerEvent,
-            window: &WindowHandle,
-            handler: &mut CompStruct,
-        ) {
-            match self {
-                WidgetSet0::W0(w) => {
-                    <::gui::gui_widget::Text as Widget<
-                        CompStruct,
-                    >>::pointer_up(w, local_pos, event, window, handler)
+                    > as Widget<CompStruct>>::event(w, event, handle)
                 }
                 WidgetSet0::W1(w) => {
-                    <::gui::gui_widget::Button<
-                        Count,
-                        CompStruct,
-                        ::gui::gui_widget::Text,
-                    > as Widget<
-                        CompStruct,
-                    >>::pointer_up(w, local_pos, event, window, handler)
-                }
-            }
-        }
-        fn pointer_move(
-            &mut self,
-            local_pos: Point,
-            event: &PointerEvent,
-            window: &WindowHandle,
-            handler: &mut CompStruct,
-        ) {
-            match self {
-                WidgetSet0::W0(w) => {
                     <::gui::gui_widget::Text as Widget<
                         CompStruct,
-                    >>::pointer_move(w, local_pos, event, window, handler)
+                    >>::event(w, event, handle)
                 }
-                WidgetSet0::W1(w) => {
+                WidgetSet0::W2(w) => {
                     <::gui::gui_widget::Button<
-                        Count,
+                        DecrementBtn,
                         CompStruct,
                         ::gui::gui_widget::Text,
-                    > as Widget<
-                        CompStruct,
-                    >>::pointer_move(w, local_pos, event, window, handler)
+                    > as Widget<CompStruct>>::event(w, event, handle)
                 }
             }
         }
@@ -164,86 +158,185 @@ mod gen {
         let pattern = message.value().expect("Value exists.");
         bundle.format_pattern(pattern, args, &mut errors)
     }
-    pub(crate) struct Count;
-    impl ToHandler for Count {
+    #[allow(non_camel_case_types)]
+    pub(crate) struct count;
+    impl Variable for count {
+        type VarType = u32;
+    }
+    #[allow(non_camel_case_types)]
+    pub(crate) struct disabled_decrement;
+    impl Variable for disabled_decrement {
+        type VarType = bool;
+    }
+    pub(crate) struct IncrementBtn;
+    impl ToHandler for IncrementBtn {
+        type BaseHandler = CompStruct;
+    }
+    pub(crate) struct DecrementBtn;
+    impl ToHandler for DecrementBtn {
         type BaseHandler = CompStruct;
     }
     #[allow(non_snake_case)]
     pub struct CounterHolder {
         comp_struct: CompStruct,
-        widget: ::gui::gui_widget::HBox<CompStruct, WidgetSet0>,
+        widget: ::gui::gui_widget::HVStack<CompStruct, WidgetSet0>,
+        Counter_Count_text: FluentArgs<'static>,
     }
     #[automatically_derived]
     impl ToComponent for CompStruct {
         type Component = CounterHolder;
         fn to_component_holder(self) -> Self::Component {
             CounterHolder {
-                widget: ::gui::gui_widget::HBox::new(
+                widget: ::gui::gui_widget::HVStack::new_vertical(
+                    WidgetID::new(0u32, 0u32),
                     10f32,
                     vec![
-                        WidgetSet0::W0(::gui::gui_widget::Text::new(String::new(),
-                        ::gui::gui_core::Colour::rgba8(33u8, 37u8, 41u8, 255u8), 24f32)),
-                        WidgetSet0::W1(::gui::gui_widget::Button::new(::gui::gui_core::Colour::rgba8(255u8,
-                        255u8, 255u8, 255u8), ::gui::gui_core::Colour::rgba8(241u8,
-                        243u8, 245u8, 255u8), ::gui::gui_core::Colour::rgba8(248u8,
-                        249u8, 250u8, 255u8), ::gui::gui_core::Colour::rgba8(248u8,
-                        249u8, 250u8, 255u8), ::gui::gui_core::Colour::rgba8(206u8,
-                        212u8, 218u8, 255u8), false,
-                        ::gui::gui_widget::Text::new(String::new(),
-                        ::gui::gui_core::Colour::rgba8(33u8, 37u8, 41u8, 255u8), 24f32)))
+                        WidgetSet0::W0(::gui::gui_widget::Button::new(WidgetID::new(0u32,
+                        1u32), ::gui::gui_core::Colour::rgba8(255u8, 255u8, 255u8,
+                        255u8), ::gui::gui_core::Colour::rgba8(241u8, 243u8, 245u8,
+                        255u8), ::gui::gui_core::Colour::rgba8(248u8, 249u8, 250u8,
+                        255u8), ::gui::gui_core::Colour::rgba8(248u8, 249u8, 250u8,
+                        255u8), ::gui::gui_core::Colour::rgba8(206u8, 212u8, 218u8,
+                        255u8), false, ::gui::gui_widget::Text::new(WidgetID::new(0u32,
+                        2u32), ::gui::gui_core::Colour::rgba8(33u8, 37u8, 41u8, 255u8),
+                        14f32))),
+                        WidgetSet0::W1(::gui::gui_widget::Text::new(WidgetID::new(0u32,
+                        3u32), ::gui::gui_core::Colour::rgba8(33u8, 37u8, 41u8, 255u8),
+                        14f32)),
+                        WidgetSet0::W2(::gui::gui_widget::Button::new(WidgetID::new(0u32,
+                        4u32), ::gui::gui_core::Colour::rgba8(255u8, 255u8, 255u8,
+                        255u8), ::gui::gui_core::Colour::rgba8(241u8, 243u8, 245u8,
+                        255u8), ::gui::gui_core::Colour::rgba8(248u8, 249u8, 250u8,
+                        255u8), ::gui::gui_core::Colour::rgba8(248u8, 249u8, 250u8,
+                        255u8), ::gui::gui_core::Colour::rgba8(206u8, 212u8, 218u8,
+                        255u8), false, ::gui::gui_widget::Text::new(WidgetID::new(0u32,
+                        5u32), ::gui::gui_core::Colour::rgba8(33u8, 37u8, 41u8, 255u8),
+                        14f32)))
                     ],
                 ),
                 comp_struct: self,
+                Counter_Count_text: FluentArgs::new(),
             }
         }
     }
     #[automatically_derived]
     impl Component for CounterHolder {
-        fn render(&mut self, mut scene: SceneBuilder, fcx: &mut FontContext) {
-            self.widget.render(&mut scene, fcx);
+        fn render<'a>(
+            &mut self,
+            scene: SceneBuilder,
+            handle: &'a mut Handle,
+            global_positions: &'a mut [Rect],
+            active_widget: Option<WidgetID>,
+            hovered_widgets: &'a [WidgetID],
+        ) -> (bool, Option<WidgetID>) {
+            let mut render_handle = RenderHandle::new(
+                handle,
+                global_positions,
+                active_widget,
+                hovered_widgets,
+                self,
+            );
+            self.widget.render(&mut scene, &mut render_handle);
+            render_handle.unwrap()
         }
         fn update_vars(&mut self, force_update: bool) {
+            let mut text = false;
+            if force_update
+                || <CompStruct as Update<count>>::is_updated(&self.comp_struct)
+            {
+                let value = <CompStruct as Update<count>>::value(&self.comp_struct);
+                text = true;
+                self.Counter_Count_text.set("count", value);
+            }
+            if force_update
+                || <CompStruct as Update<
+                    disabled_decrement,
+                >>::is_updated(&self.comp_struct)
+            {
+                let value = <CompStruct as Update<
+                    disabled_decrement,
+                >>::value(&self.comp_struct);
+                let widget = &mut self.widget.widgets(2usize).w2();
+                widget.set_disabled(value);
+            }
             if force_update {
-                let value = get_bundle_message("Counter-Other-text", None);
-                let widget = &mut self.widget.widgets(0usize).w0();
+                let value = get_bundle_message("Counter-IncrText-text", None);
+                let widget = &mut self.widget.widgets(0usize).w0().get_widget();
+                widget.set_text(value);
+            }
+            if force_update || text {
+                let value = get_bundle_message(
+                    "Counter-Count-text",
+                    Some(&self.Counter_Count_text),
+                );
+                let widget = &mut self.widget.widgets(1usize).w1();
                 widget.set_text(value);
             }
             if force_update {
-                let value = get_bundle_message("Counter-Text-text", None);
-                let widget = &mut self.widget.widgets(1usize).w1().get_widget();
+                let value = get_bundle_message("Counter-DecrText-text", None);
+                let widget = &mut self.widget.widgets(2usize).w2().get_widget();
                 widget.set_text(value);
             }
+            <CompStruct as Update<count>>::reset(&mut self.comp_struct);
+            <CompStruct as Update<disabled_decrement>>::reset(&mut self.comp_struct);
         }
-        fn resize(
+        fn resize<'a>(
             &mut self,
             constraints: LayoutConstraints,
-            fcx: &mut FontContext,
+            handle: &'a mut Handle,
+            local_positions: &'a mut [Rect],
         ) -> Size {
-            self.widget.resize(constraints, fcx)
+            let mut resize_handle = ResizeHandle::new(handle, local_positions, self);
+            self.widget.resize(constraints, &mut resize_handle);
+            resize_handle.unwrap()
         }
-        fn pointer_down(
+        fn propagate_event<'a>(
             &mut self,
-            local_pos: Point,
-            event: &PointerEvent,
-            window: &WindowHandle,
-        ) {
-            self.widget.pointer_down(local_pos, event, window, &mut self.comp_struct);
+            event: WidgetEvent,
+            global_positions: &'a [Rect],
+            active_widget: Option<WidgetID>,
+            hovered_widgets: &'a mut Vec<WidgetID>,
+        ) -> (bool, Option<WidgetID>) {
+            let mut event_handle = EventHandle::new(
+                global_positions,
+                active_widget,
+                hovered_widgets,
+                self,
+            );
+            self.widget.event(event, &mut event_handle);
+            event_handle.unwrap()
         }
-        fn pointer_up(
-            &mut self,
-            local_pos: Point,
-            event: &PointerEvent,
-            window: &WindowHandle,
-        ) {
-            self.widget.pointer_up(local_pos, event, window, &mut self.comp_struct);
+        fn largest_id(&self) -> WidgetID {
+            WidgetID::new(0u32, 4u32)
         }
-        fn pointer_move(
+        fn get_parent(&self, id: WidgetID) -> Option<WidgetID> {
+            match (id.component_id(), id.widget_id()) {
+                (0u32, 2u32) => Some(WidgetID::new(0u32, 1u32)),
+                (0u32, 5u32) => Some(WidgetID::new(0u32, 4u32)),
+                (0u32, 1u32) | (0u32, 3u32) | (0u32, 4u32) => {
+                    Some(WidgetID::new(0u32, 0u32))
+                }
+                _ => None,
+            }
+        }
+        fn event<'a>(
             &mut self,
-            local_pos: Point,
-            event: &PointerEvent,
-            window: &WindowHandle,
-        ) {
-            self.widget.pointer_move(local_pos, event, window, &mut self.comp_struct);
+            id: WidgetID,
+            event: WidgetEvent,
+            global_positions: &'a [Rect],
+            active_widget: Option<WidgetID>,
+            hovered_widgets: &'a mut Vec<WidgetID>,
+        ) -> (bool, Option<WidgetID>) {
+            let mut event_handle = EventHandle::new(
+                global_positions,
+                active_widget,
+                hovered_widgets,
+                self,
+            );
+            event_handle.unwrap()
+        }
+        fn get_handler(&mut self) -> &mut Self::Handler {
+            &mut self.comp_struct
         }
     }
 }

--- a/examples/testbuild/OUT_DIR/Counter.rs
+++ b/examples/testbuild/OUT_DIR/Counter.rs
@@ -11,25 +11,25 @@ mod gen {
         Component, LayoutConstraints, Size, ToComponent, ToHandler, Update, Variable,
     };
     enum WidgetSet0 {
-        W0(::gui::gui_widget::Button<IncrementBtn, CompStruct, ::gui::gui_widget::Text>),
-        W1(::gui::gui_widget::Text),
+        W0(::gui::gui_widget::Text),
+        W1(::gui::gui_widget::Button<IncrementBtn, CompStruct, ::gui::gui_widget::Text>),
         W2(::gui::gui_widget::Button<DecrementBtn, CompStruct, ::gui::gui_widget::Text>),
     }
     impl WidgetSet0 {
-        pub fn w0(
-            &mut self,
-        ) -> &mut ::gui::gui_widget::Button<
-            IncrementBtn,
-            CompStruct,
-            ::gui::gui_widget::Text,
-        > {
+        pub fn w0(&mut self) -> &mut ::gui::gui_widget::Text {
             if let WidgetSet0::W0(val) = self {
                 val
             } else {
                 panic!("Incorrect wrapped type.")
             }
         }
-        pub fn w1(&mut self) -> &mut ::gui::gui_widget::Text {
+        pub fn w1(
+            &mut self,
+        ) -> &mut ::gui::gui_widget::Button<
+            IncrementBtn,
+            CompStruct,
+            ::gui::gui_widget::Text,
+        > {
             if let WidgetSet0::W1(val) = self {
                 val
             } else {
@@ -54,7 +54,7 @@ mod gen {
         fn id(&self) -> WidgetID {
             match self {
                 WidgetSet0::W0(_) => WidgetID::new(0u32, 1u32),
-                WidgetSet0::W1(_) => WidgetID::new(0u32, 3u32),
+                WidgetSet0::W1(_) => WidgetID::new(0u32, 2u32),
                 WidgetSet0::W2(_) => WidgetID::new(0u32, 4u32),
             }
         }
@@ -65,16 +65,16 @@ mod gen {
         ) {
             match self {
                 WidgetSet0::W0(w) => {
+                    <::gui::gui_widget::Text as Widget<
+                        CompStruct,
+                    >>::render(w, scene, handle)
+                }
+                WidgetSet0::W1(w) => {
                     <::gui::gui_widget::Button<
                         IncrementBtn,
                         CompStruct,
                         ::gui::gui_widget::Text,
                     > as Widget<CompStruct>>::render(w, scene, handle)
-                }
-                WidgetSet0::W1(w) => {
-                    <::gui::gui_widget::Text as Widget<
-                        CompStruct,
-                    >>::render(w, scene, handle)
                 }
                 WidgetSet0::W2(w) => {
                     <::gui::gui_widget::Button<
@@ -92,16 +92,16 @@ mod gen {
         ) -> Size {
             match self {
                 WidgetSet0::W0(w) => {
+                    <::gui::gui_widget::Text as Widget<
+                        CompStruct,
+                    >>::resize(w, constraints, handle)
+                }
+                WidgetSet0::W1(w) => {
                     <::gui::gui_widget::Button<
                         IncrementBtn,
                         CompStruct,
                         ::gui::gui_widget::Text,
                     > as Widget<CompStruct>>::resize(w, constraints, handle)
-                }
-                WidgetSet0::W1(w) => {
-                    <::gui::gui_widget::Text as Widget<
-                        CompStruct,
-                    >>::resize(w, constraints, handle)
                 }
                 WidgetSet0::W2(w) => {
                     <::gui::gui_widget::Button<
@@ -115,16 +115,16 @@ mod gen {
         fn event(&mut self, event: WidgetEvent, handle: &mut EventHandle<CompStruct>) {
             match self {
                 WidgetSet0::W0(w) => {
+                    <::gui::gui_widget::Text as Widget<
+                        CompStruct,
+                    >>::event(w, event, handle)
+                }
+                WidgetSet0::W1(w) => {
                     <::gui::gui_widget::Button<
                         IncrementBtn,
                         CompStruct,
                         ::gui::gui_widget::Text,
                     > as Widget<CompStruct>>::event(w, event, handle)
-                }
-                WidgetSet0::W1(w) => {
-                    <::gui::gui_widget::Text as Widget<
-                        CompStruct,
-                    >>::event(w, event, handle)
                 }
                 WidgetSet0::W2(w) => {
                     <::gui::gui_widget::Button<
@@ -190,20 +190,20 @@ mod gen {
             CounterHolder {
                 widget: ::gui::gui_widget::HVStack::new_vertical(
                     WidgetID::new(0u32, 0u32),
-                    10f32,
+                    40f32,
                     vec![
-                        WidgetSet0::W0(::gui::gui_widget::Button::new(WidgetID::new(0u32,
-                        1u32), ::gui::gui_core::Colour::rgba8(255u8, 255u8, 255u8,
+                        WidgetSet0::W0(::gui::gui_widget::Text::new(WidgetID::new(0u32,
+                        1u32), ::gui::gui_core::Colour::rgba8(33u8, 37u8, 41u8, 255u8),
+                        40f32)),
+                        WidgetSet0::W1(::gui::gui_widget::Button::new(WidgetID::new(0u32,
+                        2u32), ::gui::gui_core::Colour::rgba8(255u8, 255u8, 255u8,
                         255u8), ::gui::gui_core::Colour::rgba8(241u8, 243u8, 245u8,
                         255u8), ::gui::gui_core::Colour::rgba8(248u8, 249u8, 250u8,
                         255u8), ::gui::gui_core::Colour::rgba8(248u8, 249u8, 250u8,
                         255u8), ::gui::gui_core::Colour::rgba8(206u8, 212u8, 218u8,
                         255u8), false, ::gui::gui_widget::Text::new(WidgetID::new(0u32,
-                        2u32), ::gui::gui_core::Colour::rgba8(33u8, 37u8, 41u8, 255u8),
-                        14f32))),
-                        WidgetSet0::W1(::gui::gui_widget::Text::new(WidgetID::new(0u32,
                         3u32), ::gui::gui_core::Colour::rgba8(33u8, 37u8, 41u8, 255u8),
-                        14f32)),
+                        40f32))),
                         WidgetSet0::W2(::gui::gui_widget::Button::new(WidgetID::new(0u32,
                         4u32), ::gui::gui_core::Colour::rgba8(255u8, 255u8, 255u8,
                         255u8), ::gui::gui_core::Colour::rgba8(241u8, 243u8, 245u8,
@@ -212,7 +212,7 @@ mod gen {
                         255u8), ::gui::gui_core::Colour::rgba8(206u8, 212u8, 218u8,
                         255u8), false, ::gui::gui_widget::Text::new(WidgetID::new(0u32,
                         5u32), ::gui::gui_core::Colour::rgba8(33u8, 37u8, 41u8, 255u8),
-                        14f32)))
+                        40f32)))
                     ],
                 ),
                 comp_struct: self,
@@ -224,9 +224,9 @@ mod gen {
         }
         fn get_parent(&self, id: WidgetID) -> Option<WidgetID> {
             match (id.component_id(), id.widget_id()) {
-                (0u32, 2u32) => Some(WidgetID::new(0u32, 1u32)),
+                (0u32, 3u32) => Some(WidgetID::new(0u32, 2u32)),
                 (0u32, 5u32) => Some(WidgetID::new(0u32, 4u32)),
-                (0u32, 1u32) | (0u32, 3u32) | (0u32, 4u32) => {
+                (0u32, 1u32) | (0u32, 2u32) | (0u32, 4u32) => {
                     Some(WidgetID::new(0u32, 0u32))
                 }
                 _ => None,
@@ -280,17 +280,17 @@ mod gen {
                 let widget = &mut self.widget.widgets(2usize).w2();
                 widget.set_disabled(value, handle_ref);
             }
-            if force_update {
-                let value = get_bundle_message("Counter-IncrText-text", None);
-                let widget = &mut self.widget.widgets(0usize).w0().get_widget();
-                widget.set_text(value, handle_ref);
-            }
             if force_update || text {
                 let value = get_bundle_message(
                     "Counter-Count-text",
                     Some(&self.Counter_Count_text),
                 );
-                let widget = &mut self.widget.widgets(1usize).w1();
+                let widget = &mut self.widget.widgets(0usize).w0();
+                widget.set_text(value, handle_ref);
+            }
+            if force_update {
+                let value = get_bundle_message("Counter-IncrText-text", None);
+                let widget = &mut self.widget.widgets(1usize).w1().get_widget();
                 widget.set_text(value, handle_ref);
             }
             if force_update {
@@ -372,17 +372,17 @@ mod gen {
             );
             let handle_ref = &mut event_handle;
             match (id.component_id(), id.widget_id()) {
-                (0u32, 2u32) => {
-                    self.widget
-                        .widgets(0usize)
-                        .w0()
-                        .get_widget()
-                        .event(event, handle_ref);
-                }
                 (0u32, 1u32) => {
                     self.widget.widgets(0usize).w0().event(event, handle_ref);
                 }
                 (0u32, 3u32) => {
+                    self.widget
+                        .widgets(1usize)
+                        .w1()
+                        .get_widget()
+                        .event(event, handle_ref);
+                }
+                (0u32, 2u32) => {
                     self.widget.widgets(1usize).w1().event(event, handle_ref);
                 }
                 (0u32, 5u32) => {

--- a/examples/testbuild/OUT_DIR/Counter.rs
+++ b/examples/testbuild/OUT_DIR/Counter.rs
@@ -333,6 +333,36 @@ mod gen {
                 hovered_widgets,
                 self,
             );
+            let handle = &mut event_handle;
+            match (id.component_id(), id.widget_id()) {
+                (0u32, 2u32) => {
+                    &mut self
+                        .widget
+                        .widgets(0usize)
+                        .w0()
+                        .get_widget()
+                        .event(event, handle)
+                }
+                (0u32, 1u32) => {
+                    &mut self.widget.widgets(0usize).w0().event(event, handle)
+                }
+                (0u32, 3u32) => {
+                    &mut self.widget.widgets(1usize).w1().event(event, handle)
+                }
+                (0u32, 5u32) => {
+                    &mut self
+                        .widget
+                        .widgets(2usize)
+                        .w2()
+                        .get_widget()
+                        .event(event, handle)
+                }
+                (0u32, 4u32) => {
+                    &mut self.widget.widgets(2usize).w2().event(event, handle)
+                }
+                (0u32, 0u32) => &mut self.widget.event(event, handle),
+                _ => {}
+            }
             event_handle.unwrap()
         }
         fn get_handler(&mut self) -> &mut Self::Handler {

--- a/examples/testbuild/OUT_DIR/Counter.rs
+++ b/examples/testbuild/OUT_DIR/Counter.rs
@@ -4,7 +4,8 @@ mod gen {
     use gui::gui_core::vello::SceneBuilder;
     use gui::gui_core::glazier::kurbo::Rect;
     use gui::gui_core::widget::{
-        Widget, WidgetID, RenderHandle, ResizeHandle, EventHandle, WidgetEvent, Handle,
+        Widget, WidgetID, RenderHandle, ResizeHandle, EventHandle, UpdateHandle,
+        WidgetEvent, Handle,
     };
     use gui::gui_core::{
         Component, LayoutConstraints, Size, ToComponent, ToHandler, Update, Variable,
@@ -252,7 +253,14 @@ mod gen {
             self.widget.render(&mut scene, &mut render_handle);
             render_handle.unwrap()
         }
-        fn update_vars(&mut self, force_update: bool) {
+        fn update_vars<'a>(
+            &mut self,
+            force_update: bool,
+            handle: &'a mut Handle,
+            global_positions: &'a [Rect],
+        ) -> bool {
+            let mut update_handle = UpdateHandle::new(handle, global_positions);
+            let handle_ref = &mut update_handle;
             let mut text = false;
             if force_update
                 || <CompStruct as Update<count>>::is_updated(&self.comp_struct)
@@ -270,12 +278,12 @@ mod gen {
                     disabled_decrement,
                 >>::value(&self.comp_struct);
                 let widget = &mut self.widget.widgets(2usize).w2();
-                widget.set_disabled(value);
+                widget.set_disabled(value, handle_ref);
             }
             if force_update {
                 let value = get_bundle_message("Counter-IncrText-text", None);
                 let widget = &mut self.widget.widgets(0usize).w0().get_widget();
-                widget.set_text(value);
+                widget.set_text(value, handle_ref);
             }
             if force_update || text {
                 let value = get_bundle_message(
@@ -283,15 +291,16 @@ mod gen {
                     Some(&self.Counter_Count_text),
                 );
                 let widget = &mut self.widget.widgets(1usize).w1();
-                widget.set_text(value);
+                widget.set_text(value, handle_ref);
             }
             if force_update {
                 let value = get_bundle_message("Counter-DecrText-text", None);
                 let widget = &mut self.widget.widgets(2usize).w2().get_widget();
-                widget.set_text(value);
+                widget.set_text(value, handle_ref);
             }
             <CompStruct as Update<count>>::reset(&mut self.comp_struct);
             <CompStruct as Update<disabled_decrement>>::reset(&mut self.comp_struct);
+            update_handle.unwrap()
         }
         fn resize<'a>(
             &mut self,

--- a/examples/testbuild/simple.yaml
+++ b/examples/testbuild/simple.yaml
@@ -1,24 +1,39 @@
 styles:
-  - widget: Text
-    properties:
-      size: 24
-
 components:
   - name: Counter # Names for components must be unique
+    variables:
+      - name: count
+        type: u32
+      - name: disabled_decrement
+        type: bool
     child:
-      widget: HBox
+      widget: VStack
+      layoutProperties: # Under the hood these settings create a layout widget
+        # so that custom widgets do not need to deal with layout.
+        padding: 10
       properties:
         children:
-          - widget: Text
-            name: Other
+          - name: IncrementBtn
+            widget: Button
             properties:
-              text: Hiya
+              child:
+                name: IncrText
+                widget: Text
+                properties:
+                  text: Increment # Uses Fluent syntax https://projectfluent.org/
+
           - name: Count
+            widget: Text
+            properties:
+              text: "{$count}" # Can use any variable from the component
+
+          - name: DecrementBtn
             widget: Button
             properties:
               disabled:
-                variable: disabled
+                variable: disabled_decrement
               child:
+                name: DecrText
                 widget: Text
                 properties:
-                  text: Testsfa
+                  text: Decrement

--- a/examples/testbuild/simple.yaml
+++ b/examples/testbuild/simple.yaml
@@ -1,4 +1,7 @@
 styles:
+  - widget: Text
+    properties:
+      size: 40
 components:
   - name: Counter # Names for components must be unique
     variables:
@@ -12,7 +15,13 @@ components:
         # so that custom widgets do not need to deal with layout.
         padding: 10
       properties:
+        spacing: 40
         children:
+          - name: Count
+            widget: Text
+            properties:
+              text: "{$count}" # Can use any variable from the component
+
           - name: IncrementBtn
             widget: Button
             properties:
@@ -21,11 +30,6 @@ components:
                 widget: Text
                 properties:
                   text: Increment # Uses Fluent syntax https://projectfluent.org/
-
-          - name: Count
-            widget: Text
-            properties:
-              text: "{$count}" # Can use any variable from the component
 
           - name: DecrementBtn
             widget: Button

--- a/gui-build/src/component.rs
+++ b/gui-build/src/component.rs
@@ -109,7 +109,7 @@ pub fn create_component(out_dir: &Path, component: &ComponentDeclaration) -> any
             use super::__private_CompStruct as CompStruct;
             use gui::gui_core::vello::SceneBuilder;
             use gui::gui_core::glazier::kurbo::Rect;
-            use gui::gui_core::widget::{Widget, WidgetID, RenderHandle, ResizeHandle, EventHandle, WidgetEvent, Handle};
+            use gui::gui_core::widget::{Widget, WidgetID, RenderHandle, ResizeHandle, EventHandle, UpdateHandle, WidgetEvent, Handle};
             use gui::gui_core::{Component, LayoutConstraints, Size, ToComponent, ToHandler, Update, Variable};
 
             #widget_set
@@ -166,11 +166,19 @@ pub fn create_component(out_dir: &Path, component: &ComponentDeclaration) -> any
                     render_handle.unwrap()
                 }
 
-                fn update_vars(&mut self, force_update: bool) {
+                fn update_vars<'a>(
+                    &mut self,
+                    force_update: bool,
+                    handle: &'a mut Handle,
+                    global_positions: &'a [Rect],
+                ) -> bool {
+                    let mut update_handle = UpdateHandle::new(handle, global_positions);
+                    let handle_ref = &mut update_handle;
                     #( let mut #fluent_properties = false; )*
                     #if_update
                     #prop_update
                     #( <CompStruct as Update<#var_names>>::reset(&mut self.comp_struct); )*
+                    update_handle.unwrap()
                 }
 
                 fn resize<'a>(

--- a/gui-build/src/component.rs
+++ b/gui-build/src/component.rs
@@ -140,7 +140,6 @@ pub fn create_component(out_dir: &Path, component: &ComponentDeclaration) -> any
                 }
 
                 fn largest_id(&self) -> WidgetID {
-                    // TODO largest id is wrong
                     #largest_id
                 }
 

--- a/gui-build/src/widget.rs
+++ b/gui-build/src/widget.rs
@@ -115,6 +115,7 @@ impl<'a> Widget<'a> {
     ) {
         let widget_ident = Ident::new("widget", Span::call_site());
         let value_ident = Ident::new("value", Span::call_site());
+        let handle_ident = Ident::new("handle_ref", Span::call_site());
         let string_var_name = &var.name;
 
         let mut update_stream = TokenStream::new();
@@ -124,6 +125,7 @@ impl<'a> Widget<'a> {
                 prop,
                 &widget_ident,
                 &value_ident,
+                &handle_ident,
                 &mut update_stream,
             );
         }
@@ -169,6 +171,7 @@ impl<'a> Widget<'a> {
         let widget_stmt = widget_stmt.map_or_else(|| quote! {&mut self.widget}, Clone::clone);
         let widget = Ident::new("widget", Span::call_site());
         let value = Ident::new("value", Span::call_site());
+        let handle_ident = Ident::new("handle_ref", Span::call_site());
 
         for fluent in &self.fluents {
             let property_ident = (!fluent.fluent.vars.is_empty()).then_some(&fluent.property_ident);
@@ -186,6 +189,7 @@ impl<'a> Widget<'a> {
                 fluent.property,
                 &widget,
                 &value,
+                &handle_ident,
                 &mut on_property_update,
             );
             stream.extend(quote! {

--- a/gui-build/src/widget_set.rs
+++ b/gui-build/src/widget_set.rs
@@ -1,5 +1,6 @@
 use crate::widget::Widget;
 use gui_core::parse::WidgetDeclaration;
+use gui_core::widget::WidgetID;
 use itertools::Itertools;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
@@ -90,6 +91,8 @@ impl<'a> WidgetSet<'a> {
                 .map(|(_, w)| w.gen_widget_type())
                 .collect_vec();
 
+            let ids = self.widgets.iter().map(|(_, w)| w.id);
+
             stream.extend(quote! {
                 enum #widget_set {
                     #( #variants(#types) ),*
@@ -108,35 +111,30 @@ impl<'a> WidgetSet<'a> {
                 }
 
                 impl Widget<CompStruct> for #widget_set {
-                    fn render(&mut self, scene: &mut SceneBuilder, fcx: &mut FontContext) {
+                    fn id(&self) -> WidgetID {
                         match self {
-                            #( #widget_set::#variants(w) => <#types as Widget<CompStruct>>::render(w, scene, fcx) ),*
+                            #( #widget_set::#variants(w) => #ids ),*
                         }
                     }
 
-                    fn resize(&mut self, constraints: LayoutConstraints, fcx: &mut FontContext) -> Size {
+                     fn render(&mut self, scene: &mut SceneBuilder, handle: &mut RenderHandle<CompStruct>) {
                         match self {
-                            #( #widget_set::#variants(w) => <#types as Widget<CompStruct>>::resize(w, constraints, fcx) ),*
+                            #( #widget_set::#variants(w) => <#types as Widget<CompStruct>>::render(w, scene, handle) ),*
                         }
                     }
 
-                    fn pointer_down(&mut self, local_pos: Point, event: &PointerEvent, window: &WindowHandle, handler: &mut CompStruct) {
+                    fn resize(&mut self, constraints: LayoutConstraints, handle: &mut ResizeHandle<CompStruct>) -> Size {
                         match self {
-                            #( #widget_set::#variants(w) => <#types as Widget<CompStruct>>::pointer_down(w, local_pos, event, window, handler) ),*
+                            #( #widget_set::#variants(w) => <#types as Widget<CompStruct>>::resize(w, constraints, handle) ),*
                         }
                     }
 
-                    fn pointer_up(&mut self, local_pos: Point, event: &PointerEvent, window: &WindowHandle, handler: &mut CompStruct) {
+                    fn event(&mut self, event: WidgetEvent, handle: &mut EventHandle<CompStruct>) {
                         match self {
-                            #( #widget_set::#variants(w) => <#types as Widget<CompStruct>>::pointer_up(w, local_pos, event, window, handler) ),*
+                            #( #widget_set::#variants(w) => <#types as Widget<CompStruct>>::event(w, event, handle) ),*
                         }
                     }
 
-                    fn pointer_move(&mut self, local_pos: Point, event: &PointerEvent, window: &WindowHandle, handler: &mut CompStruct) {
-                        match self {
-                            #( #widget_set::#variants(w) => <#types as Widget<CompStruct>>::pointer_move(w, local_pos, event, window, handler) ),*
-                        }
-                    }
                 }
             });
         }
@@ -162,5 +160,12 @@ impl<'a> WidgetSet<'a> {
                 }
                 (s, w)
             })
+    }
+
+    pub fn largest_id(&self) -> Option<WidgetID> {
+        self.widgets
+            .iter()
+            .map(|(_, w)| w.id)
+            .max_by_key(|i| i.widget_id())
     }
 }

--- a/gui-build/src/widget_set.rs
+++ b/gui-build/src/widget_set.rs
@@ -2,7 +2,7 @@ use crate::widget::Widget;
 use gui_core::parse::WidgetDeclaration;
 use gui_core::widget::WidgetID;
 use itertools::Itertools;
-use proc_macro2::{Ident, TokenStream};
+use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -31,9 +31,9 @@ impl<'a> WidgetSet<'a> {
         })
     }
 
-    pub fn gen_widget_type(&self, component_holder: &Ident) -> TokenStream {
+    pub fn gen_widget_type(&self) -> TokenStream {
         match &self.widgets[..] {
-            [(_, child)] => child.gen_widget_type(&component_holder),
+            [(_, child)] => child.gen_widget_type(),
             [] => quote!(()),
             _ => {
                 let count = self.count.expect("widget set should be created.");
@@ -68,7 +68,7 @@ impl<'a> WidgetSet<'a> {
         }
     }
 
-    pub fn gen_widget_set(&self, component_holder: &Ident, stream: &mut TokenStream) {
+    pub fn gen_widget_set(&self, stream: &mut TokenStream) {
         if let Some(count) = self.count {
             let widget_set = format_ident!("WidgetSet{count}");
 
@@ -88,7 +88,7 @@ impl<'a> WidgetSet<'a> {
             let types = self
                 .widgets
                 .iter()
-                .map(|(_, w)| w.gen_widget_type(component_holder))
+                .map(|(_, w)| w.gen_widget_type())
                 .collect_vec();
 
             let ids = self.widgets.iter().map(|(_, w)| w.id);
@@ -110,28 +110,28 @@ impl<'a> WidgetSet<'a> {
                     )*
                 }
 
-                impl Widget<#component_holder> for #widget_set {
+                impl Widget<CompStruct> for #widget_set {
                     fn id(&self) -> WidgetID {
                         match self {
                             #( #widget_set::#variants(_) => #ids ),*
                         }
                     }
 
-                     fn render(&mut self, scene: &mut SceneBuilder, handle: &mut RenderHandle<#component_holder>) {
+                     fn render(&mut self, scene: &mut SceneBuilder, handle: &mut RenderHandle<CompStruct>) {
                         match self {
-                            #( #widget_set::#variants(w) => <#types as Widget<#component_holder>>::render(w, scene, handle) ),*
+                            #( #widget_set::#variants(w) => <#types as Widget<CompStruct>>::render(w, scene, handle) ),*
                         }
                     }
 
-                    fn resize(&mut self, constraints: LayoutConstraints, handle: &mut ResizeHandle<#component_holder>) -> Size {
+                    fn resize(&mut self, constraints: LayoutConstraints, handle: &mut ResizeHandle<CompStruct>) -> Size {
                         match self {
-                            #( #widget_set::#variants(w) => <#types as Widget<#component_holder>>::resize(w, constraints, handle) ),*
+                            #( #widget_set::#variants(w) => <#types as Widget<CompStruct>>::resize(w, constraints, handle) ),*
                         }
                     }
 
-                    fn event(&mut self, event: WidgetEvent, handle: &mut EventHandle<#component_holder>) {
+                    fn event(&mut self, event: WidgetEvent, handle: &mut EventHandle<CompStruct>) {
                         match self {
-                            #( #widget_set::#variants(w) => <#types as Widget<#component_holder>>::event(w, event, handle) ),*
+                            #( #widget_set::#variants(w) => <#types as Widget<CompStruct>>::event(w, event, handle) ),*
                         }
                     }
 
@@ -140,7 +140,7 @@ impl<'a> WidgetSet<'a> {
         }
 
         for (_, w) in &self.widgets {
-            w.gen_widget_set(component_holder, stream)
+            w.gen_widget_set(stream)
         }
     }
 

--- a/gui-build/src/widget_set.rs
+++ b/gui-build/src/widget_set.rs
@@ -15,12 +15,13 @@ impl<'a> WidgetSet<'a> {
     pub fn new(
         component_name: &str,
         widgets: Vec<(TokenStream, &'a WidgetDeclaration)>,
+        component_id: u32,
     ) -> anyhow::Result<Self> {
         static COUNTER: AtomicU32 = AtomicU32::new(0);
 
         let widgets = widgets
             .into_iter()
-            .map(|(s, w)| Ok((s, Widget::new_inner(component_name, w)?)))
+            .map(|(s, w)| Ok((s, Widget::new_inner(component_name, w, component_id)?)))
             .collect::<anyhow::Result<Vec<_>>>()?;
 
         Ok(Self {

--- a/gui-build/src/widget_set.rs
+++ b/gui-build/src/widget_set.rs
@@ -165,7 +165,7 @@ impl<'a> WidgetSet<'a> {
     pub fn largest_id(&self) -> Option<WidgetID> {
         self.widgets
             .iter()
-            .map(|(_, w)| w.id)
+            .map(|(_, w)| w.get_largest_id())
             .max_by_key(|i| i.widget_id())
     }
 }

--- a/gui-core/src/handles.rs
+++ b/gui-core/src/handles.rs
@@ -116,8 +116,6 @@ impl<'a, T: ToComponent> RenderHandle<'a, T> {
             let mut builder = SceneBuilder::for_fragment(&mut fragment);
             w.render(&mut builder, self);
 
-            dbg!((std::any::type_name_of_val(w), vector));
-
             scene.append(&fragment, Some(Affine::translate(vector)));
         }
     }
@@ -136,14 +134,7 @@ impl<'a, T: ToComponent> RenderHandle<'a, T> {
 
     pub fn get_local_rect(&self, id: WidgetID) -> Rect {
         let global = self.get_global_rect(id);
-        let parent_pos = self
-            .comp_struct
-            .get_parent(id)
-            .map_or_else(Point::default, |id| {
-                self.global_positions[id.widget_id() as usize].origin()
-            });
-        let vector = global.origin() - parent_pos;
-        global.with_origin(vector.to_point())
+        global.with_origin((0.0, 0.0))
     }
 }
 
@@ -248,14 +239,7 @@ impl<'a, T: ToComponent> EventHandle<'a, T> {
 
     pub fn get_local_rect(&self, id: WidgetID) -> Rect {
         let global = self.get_global_rect(id);
-        let parent_pos = self
-            .comp_struct
-            .get_parent(id)
-            .map_or_else(Point::default, |id| {
-                self.global_positions[id.widget_id() as usize].origin()
-            });
-        let vector = global.origin() - parent_pos;
-        global.with_origin(vector.to_point())
+        global.with_origin((0.0, 0.0))
     }
 
     pub fn propagate_event<'b, W: Widget<T> + 'b>(

--- a/gui-core/src/handles.rs
+++ b/gui-core/src/handles.rs
@@ -81,6 +81,8 @@ impl<'a, T: ToComponent> RenderHandle<'a, T> {
             let mut builder = SceneBuilder::for_fragment(&mut fragment);
             w.render(&mut builder, self);
 
+            dbg!((w.id(), vector));
+
             scene.append(&fragment, Some(Affine::translate(vector)));
         }
     }

--- a/gui-core/src/handles.rs
+++ b/gui-core/src/handles.rs
@@ -20,6 +20,41 @@ impl Default for Handle {
     }
 }
 
+pub struct UpdateHandle<'a> {
+    handle: &'a mut Handle,
+    global_positions: &'a [Rect],
+    resize: bool,
+}
+
+impl<'a> UpdateHandle<'a> {
+    pub fn new(handle: &'a mut Handle, global_positions: &'a [Rect]) -> Self {
+        Self {
+            handle,
+            global_positions,
+            resize: false,
+        }
+    }
+    pub fn get_fcx(&mut self) -> &mut FontContext {
+        &mut self.handle.fcx
+    }
+    pub fn resize(&mut self) {
+        self.resize = true;
+    }
+    pub fn unwrap(self) -> bool {
+        self.resize
+    }
+    pub fn invalidate_id(&mut self, id: WidgetID) {
+        let rect = self.global_positions[id.widget_id() as usize];
+        self.handle.window.invalidate_rect(rect);
+    }
+    pub fn invalidate_rect(&mut self, id: WidgetID, local_rect: Rect) {
+        let global_rect = self.global_positions[id.widget_id() as usize];
+        self.handle
+            .window
+            .invalidate_rect(local_rect + global_rect.origin().to_vec2())
+    }
+}
+
 pub struct RenderHandle<'a, T> {
     handle: &'a mut Handle,
     global_positions: &'a mut [Rect],

--- a/gui-core/src/handles.rs
+++ b/gui-core/src/handles.rs
@@ -1,7 +1,7 @@
 use crate::widget::{Widget, WidgetEvent, WidgetID};
 use crate::{LayoutConstraints, Point, Size, ToComponent};
 use glazier::kurbo::{Affine, Rect};
-use glazier::WindowHandle;
+use glazier::{Cursor, WindowHandle};
 use parley::FontContext;
 use vello::{SceneBuilder, SceneFragment};
 
@@ -294,6 +294,9 @@ impl<'a, T: ToComponent> EventHandle<'a, T> {
 
     pub fn is_hovered(&self, id: WidgetID) -> bool {
         self.hovered_widgets.contains(&id)
+    }
+    pub fn set_cursor(&mut self, cursor: &Cursor) {
+        self.handle.window.set_cursor(cursor)
     }
     pub fn get_handler(&mut self) -> &mut T {
         self.comp_struct

--- a/gui-core/src/handles.rs
+++ b/gui-core/src/handles.rs
@@ -116,7 +116,7 @@ impl<'a, T: ToComponent> RenderHandle<'a, T> {
             let mut builder = SceneBuilder::for_fragment(&mut fragment);
             w.render(&mut builder, self);
 
-            dbg!((w.id(), vector));
+            dbg!((std::any::type_name_of_val(w), vector));
 
             scene.append(&fragment, Some(Affine::translate(vector)));
         }

--- a/gui-core/src/handles.rs
+++ b/gui-core/src/handles.rs
@@ -1,0 +1,265 @@
+use crate::widget::{Widget, WidgetEvent, WidgetID};
+use crate::{Component, LayoutConstraints, Point, Size};
+use glazier::kurbo::{Affine, Rect};
+use glazier::WindowHandle;
+use parley::FontContext;
+use vello::{SceneBuilder, SceneFragment};
+
+#[derive(Clone)]
+pub struct Handle {
+    pub fcx: FontContext,
+    pub window: WindowHandle,
+}
+
+pub struct RenderHandle<'a, C> {
+    handle: &'a mut Handle,
+    global_positions: &'a mut [Rect],
+    resize: bool,
+    active_widget: Option<WidgetID>,
+    hovered_widgets: &'a [WidgetID],
+    component: &'a mut C,
+}
+
+impl<'a, C: Component> RenderHandle<'a, C> {
+    pub fn new(
+        handle: &'a mut Handle,
+        global_positions: &'a mut Vec<Rect>,
+        component: &'a mut C,
+        active_widget: Option<WidgetID>,
+        hovered_widgets: &'a [WidgetID],
+    ) -> Self {
+        Self {
+            handle,
+            component,
+            global_positions,
+            active_widget,
+            hovered_widgets,
+            resize: false,
+        }
+    }
+
+    pub fn get_fcx(&mut self) -> &mut FontContext {
+        &mut self.handle.fcx
+    }
+
+    pub fn resize(&mut self) {
+        self.resize = true;
+    }
+
+    pub fn unwrap(self) -> bool {
+        self.resize
+    }
+
+    pub fn render_widgets<'b, W: Widget<C> + 'b>(
+        &mut self,
+        scene: &mut SceneBuilder,
+        iter: impl Iterator<Item = &'b mut W>,
+    ) {
+        let mut parent_origin: Option<Point> = None;
+        for w in iter {
+            let id = w.id();
+            let child_pos = self.global_positions[id.widget_id() as usize];
+            let parent_origin = *parent_origin.get_or_insert_with(|| {
+                self.component
+                    .get_parent(id)
+                    .map_or_else(Point::default, |parent_id| {
+                        self.global_positions[parent_id.widget_id() as usize].origin()
+                    })
+            });
+            let vector = child_pos.origin() - parent_origin;
+
+            let mut fragment = SceneFragment::new();
+            let mut builder = SceneBuilder::for_fragment(&mut fragment);
+            w.render(&mut builder, self);
+
+            scene.append(&fragment, Some(Affine::translate(vector)));
+        }
+    }
+
+    pub fn is_active(&self, id: WidgetID) -> bool {
+        self.active_widget == Some(id)
+    }
+
+    pub fn is_hovered(&self, id: WidgetID) -> bool {
+        self.hovered_widgets.contains(&id)
+    }
+
+    pub fn get_global_rect(&self, id: WidgetID) -> Rect {
+        self.global_positions[id.widget_id() as usize]
+    }
+
+    pub fn get_local_rect(&self, id: WidgetID) -> Rect {
+        let global = self.get_global_rect(id);
+        let parent_pos = self
+            .component
+            .get_parent(id)
+            .map_or_else(Point::default, |id| {
+                self.global_positions[id.widget_id() as usize].origin()
+            });
+        let vector = global.origin() - parent_pos;
+        global.with_origin(vector.to_point())
+    }
+}
+
+pub struct ResizeHandle<'a, C> {
+    handle: &'a mut Handle,
+    local_positions: &'a mut [Rect],
+    _component: &'a mut C,
+}
+
+impl<'a, C: Component> ResizeHandle<'a, C> {
+    pub fn new(
+        handle: &'a mut Handle,
+        local_positions: &'a mut Vec<Rect>,
+        component: &'a mut C,
+    ) -> Self {
+        Self {
+            handle,
+            _component: component,
+            local_positions,
+        }
+    }
+    pub fn get_fcx(&mut self) -> &mut FontContext {
+        &mut self.handle.fcx
+    }
+
+    pub fn position_widget(&mut self, rect: Rect, child_id: WidgetID) {
+        self.local_positions[child_id.widget_id() as usize] = rect;
+    }
+
+    pub fn layout_widget<W: Widget<C>>(
+        &mut self,
+        origin: Point,
+        child: &mut W,
+        constraints: LayoutConstraints,
+    ) -> Size {
+        let s = child.resize(constraints, self);
+        self.position_widget(Rect::from_origin_size(origin, s), child.id());
+        s
+    }
+}
+
+pub struct EventHandle<'a, C> {
+    handle: &'a mut Handle,
+    component: &'a mut C,
+    global_positions: &'a [Rect],
+    resize: bool,
+    active_widget: Option<WidgetID>,
+    hovered_widgets: &'a mut Vec<WidgetID>,
+}
+
+impl<'a, C: Component> EventHandle<'a, C> {
+    pub fn new(
+        handle: &'a mut Handle,
+        component: &'a mut C,
+        global_positions: &'a mut Vec<Rect>,
+        active_widget: Option<WidgetID>,
+        hovered_widgets: &'a mut Vec<WidgetID>,
+    ) -> Self {
+        Self {
+            handle,
+            component,
+            resize: false,
+            global_positions,
+            active_widget,
+            hovered_widgets,
+        }
+    }
+    pub fn get_fcx(&mut self) -> &mut FontContext {
+        &mut self.handle.fcx
+    }
+
+    pub fn invalidate_id(&mut self, id: WidgetID) {
+        let rect = self.global_positions[id.widget_id() as usize];
+        self.handle.window.invalidate_rect(rect);
+    }
+
+    pub fn invalidate_rect(&mut self, id: WidgetID, local_rect: Rect) {
+        let global_rect = self.global_positions[id.widget_id() as usize];
+        self.handle
+            .window
+            .invalidate_rect(local_rect + global_rect.origin().to_vec2())
+    }
+
+    pub fn resize(&mut self) {
+        self.resize = true;
+    }
+
+    pub fn get_local_point(&self, id: WidgetID, pos: Point) -> Point {
+        let global_rect = self.global_positions[id.widget_id() as usize];
+        (pos - global_rect.origin()).to_point()
+    }
+
+    pub fn get_global_rect(&self, id: WidgetID) -> Rect {
+        self.global_positions[id.widget_id() as usize]
+    }
+
+    pub fn get_local_rect(&self, id: WidgetID) -> Rect {
+        let global = self.get_global_rect(id);
+        let parent_pos = self
+            .component
+            .get_parent(id)
+            .map_or_else(Point::default, |id| {
+                self.global_positions[id.widget_id() as usize].origin()
+            });
+        let vector = global.origin() - parent_pos;
+        global.with_origin(vector.to_point())
+    }
+
+    pub fn propagate_event<'b, W: Widget<C> + 'b>(
+        &mut self,
+        event: WidgetEvent,
+        iter: impl Iterator<Item = &'b mut W>,
+    ) {
+        for w in iter {
+            let id = w.id();
+
+            if let Some(point) = event.get_point() {
+                let child_pos = self.global_positions[id.widget_id() as usize];
+                if child_pos.contains(point) {
+                    w.event(event, self);
+                    return;
+                }
+            }
+
+            w.event(event.clone(), self);
+        }
+    }
+
+    pub fn unwrap(self) -> bool {
+        self.resize
+    }
+
+    pub fn set_active(&mut self, id: WidgetID, active: bool) {
+        if let Some(old_id) = self.active_widget {
+            if !active && old_id != id {
+                return;
+            }
+            if !(active && old_id == id) {
+                self.component.event(old_id, WidgetEvent::ActiveChange);
+            }
+        }
+        self.active_widget = active.then_some(id);
+    }
+
+    pub fn add_hover(&mut self, id: WidgetID) -> bool {
+        if !self.hovered_widgets.contains(&id) {
+            self.hovered_widgets.push(id);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn is_active(&self, id: WidgetID) -> bool {
+        self.active_widget == Some(id)
+    }
+
+    pub fn is_hovered(&self, id: WidgetID) -> bool {
+        self.hovered_widgets.contains(&id)
+    }
+
+    pub fn get_handler(&mut self) -> &mut C::Handler {
+        self.component.get_handler()
+    }
+}

--- a/gui-core/src/lib.rs
+++ b/gui-core/src/lib.rs
@@ -23,11 +23,10 @@ pub use vello::SceneBuilder;
 
 #[allow(dead_code)]
 struct TestBoxable {
-    test: Box<dyn Component<Handler = ()>>,
+    test: Box<dyn Component>,
 }
 
 pub trait Component {
-    type Handler;
     fn render<'a>(
         &mut self,
         scene: SceneBuilder,
@@ -63,12 +62,13 @@ pub trait Component {
         active_widget: &'a mut Option<WidgetID>,
         hovered_widgets: &'a mut Vec<WidgetID>,
     ) -> bool;
-    fn get_handler(&mut self) -> &mut Self::Handler;
 }
 
 pub trait ToComponent {
     type Component: Component;
     fn to_component_holder(self) -> Self::Component;
+    fn largest_id(&self) -> WidgetID;
+    fn get_parent(&self, id: WidgetID) -> Option<WidgetID>;
 }
 
 pub trait Variable {

--- a/gui-core/src/lib.rs
+++ b/gui-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod common;
 pub mod parse;
 pub mod widget;
 
+mod handles;
 pub mod layout;
 
 pub use layout::LayoutConstraints;
@@ -15,18 +16,24 @@ use glazier::{PointerEvent, WindowHandle};
 pub use parley;
 pub use vello;
 
+use crate::handles::Handle;
+use crate::widget::{WidgetEvent, WidgetID};
 pub use parley::font::FontContext;
 pub use vello::SceneBuilder;
 
 #[allow(dead_code)]
 struct TestBoxable {
-    test: Box<dyn Component>,
+    test: Box<dyn Component<Handler = ()>>,
 }
 
 pub trait Component {
+    type Handler;
     fn render(&mut self, scene: SceneBuilder, fcx: &mut FontContext);
     fn update_vars(&mut self, force_update: bool);
     fn resize(&mut self, constraints: LayoutConstraints, fcx: &mut FontContext) -> Size;
+    fn get_parent(&self, id: WidgetID) -> Option<WidgetID>;
+    fn event(&mut self, id: WidgetID, event: WidgetEvent);
+    fn get_handler(&mut self) -> &mut Self::Handler;
     fn pointer_down(&mut self, local_pos: Point, event: &PointerEvent, window: &WindowHandle);
     fn pointer_up(&mut self, local_pos: Point, event: &PointerEvent, window: &WindowHandle);
     fn pointer_move(&mut self, local_pos: Point, event: &PointerEvent, window: &WindowHandle);

--- a/gui-core/src/lib.rs
+++ b/gui-core/src/lib.rs
@@ -12,10 +12,12 @@ pub use vello::kurbo::Size;
 
 pub use glazier;
 pub use glazier::kurbo::Point;
+use glazier::kurbo::Rect;
 use glazier::{PointerEvent, WindowHandle};
 pub use parley;
 pub use vello;
 
+use crate::handles::{EventHandle, Handle};
 use crate::widget::{WidgetEvent, WidgetID};
 pub use parley::font::FontContext;
 pub use vello::SceneBuilder;
@@ -27,15 +29,39 @@ struct TestBoxable {
 
 pub trait Component {
     type Handler;
-    fn render(&mut self, scene: SceneBuilder, fcx: &mut FontContext);
+    fn render<'a>(
+        &mut self,
+        scene: SceneBuilder,
+        handle: &'a mut Handle,
+        global_positions: &'a mut [Rect],
+        active_widget: Option<WidgetID>,
+        hovered_widgets: &'a [WidgetID],
+    ) -> (bool, Option<WidgetID>);
     fn update_vars(&mut self, force_update: bool);
-    fn resize(&mut self, constraints: LayoutConstraints, fcx: &mut FontContext) -> Size;
+    fn resize<'a>(
+        &mut self,
+        constraints: LayoutConstraints,
+        handle: &'a mut Handle,
+        local_positions: &'a mut [Rect],
+    ) -> Size;
+
+    fn propagate_event<'a>(
+        &mut self,
+        event: WidgetEvent,
+        global_positions: &'a [Rect],
+        hovered_widgets: &'a mut Vec<WidgetID>,
+    ) -> (bool, Option<WidgetID>);
+    fn largest_id(&self) -> WidgetID;
     fn get_parent(&self, id: WidgetID) -> Option<WidgetID>;
-    fn event(&mut self, id: WidgetID, event: WidgetEvent);
+    fn event<'a>(
+        &mut self,
+        id: WidgetID,
+        event: WidgetEvent,
+        global_positions: &'a [Rect],
+        active_widget: Option<WidgetID>,
+        hovered_widgets: &'a mut Vec<WidgetID>,
+    ) -> (bool, Option<WidgetID>);
     fn get_handler(&mut self) -> &mut Self::Handler;
-    fn pointer_down(&mut self, local_pos: Point, event: &PointerEvent, window: &WindowHandle);
-    fn pointer_up(&mut self, local_pos: Point, event: &PointerEvent, window: &WindowHandle);
-    fn pointer_move(&mut self, local_pos: Point, event: &PointerEvent, window: &WindowHandle);
 }
 
 pub trait ToComponent {

--- a/gui-core/src/lib.rs
+++ b/gui-core/src/lib.rs
@@ -13,11 +13,10 @@ pub use vello::kurbo::Size;
 pub use glazier;
 pub use glazier::kurbo::Point;
 use glazier::kurbo::Rect;
-use glazier::{PointerEvent, WindowHandle};
 pub use parley;
 pub use vello;
 
-use crate::handles::{EventHandle, Handle};
+use crate::handles::Handle;
 use crate::widget::{WidgetEvent, WidgetID};
 pub use parley::font::FontContext;
 pub use vello::SceneBuilder;
@@ -34,9 +33,9 @@ pub trait Component {
         scene: SceneBuilder,
         handle: &'a mut Handle,
         global_positions: &'a mut [Rect],
-        active_widget: Option<WidgetID>,
+        active_widget: &'a mut Option<WidgetID>,
         hovered_widgets: &'a [WidgetID],
-    ) -> (bool, Option<WidgetID>);
+    ) -> bool;
     fn update_vars(&mut self, force_update: bool);
     fn resize<'a>(
         &mut self,
@@ -48,19 +47,22 @@ pub trait Component {
     fn propagate_event<'a>(
         &mut self,
         event: WidgetEvent,
+        handle: &'a mut Handle,
         global_positions: &'a [Rect],
+        active_widget: &'a mut Option<WidgetID>,
         hovered_widgets: &'a mut Vec<WidgetID>,
-    ) -> (bool, Option<WidgetID>);
+    ) -> bool;
     fn largest_id(&self) -> WidgetID;
     fn get_parent(&self, id: WidgetID) -> Option<WidgetID>;
     fn event<'a>(
         &mut self,
         id: WidgetID,
         event: WidgetEvent,
+        handle: &'a mut Handle,
         global_positions: &'a [Rect],
-        active_widget: Option<WidgetID>,
+        active_widget: &'a mut Option<WidgetID>,
         hovered_widgets: &'a mut Vec<WidgetID>,
-    ) -> (bool, Option<WidgetID>);
+    ) -> bool;
     fn get_handler(&mut self) -> &mut Self::Handler;
 }
 

--- a/gui-core/src/lib.rs
+++ b/gui-core/src/lib.rs
@@ -16,7 +16,6 @@ use glazier::{PointerEvent, WindowHandle};
 pub use parley;
 pub use vello;
 
-use crate::handles::Handle;
 use crate::widget::{WidgetEvent, WidgetID};
 pub use parley::font::FontContext;
 pub use vello::SceneBuilder;

--- a/gui-core/src/lib.rs
+++ b/gui-core/src/lib.rs
@@ -35,7 +35,12 @@ pub trait Component {
         active_widget: &'a mut Option<WidgetID>,
         hovered_widgets: &'a [WidgetID],
     ) -> bool;
-    fn update_vars(&mut self, force_update: bool);
+    fn update_vars<'a>(
+        &mut self,
+        force_update: bool,
+        handle: &'a mut Handle,
+        global_positions: &'a [Rect],
+    ) -> bool;
     fn resize<'a>(
         &mut self,
         constraints: LayoutConstraints,

--- a/gui-core/src/widget.rs
+++ b/gui-core/src/widget.rs
@@ -1,4 +1,4 @@
-pub use crate::handles::{EventHandle, Handle, RenderHandle, ResizeHandle};
+pub use crate::handles::{EventHandle, Handle, RenderHandle, ResizeHandle, UpdateHandle};
 use crate::layout::LayoutConstraints;
 use crate::parse::fluent::Fluent;
 use crate::parse::WidgetDeclaration;
@@ -109,6 +109,7 @@ pub trait WidgetBuilder: std::fmt::Debug + AsAny + DynClone {
         property: &'static str,
         widget: &Ident,
         value: &Ident,
+        handle: &Ident,
         stream: &mut TokenStream,
     );
     fn get_fluents(&self) -> Vec<(&'static str, &Fluent)>;

--- a/gui-core/src/widget.rs
+++ b/gui-core/src/widget.rs
@@ -12,7 +12,7 @@ use std::any::Any;
 use vello::kurbo::Size;
 use vello::SceneBuilder;
 
-#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Default)]
 pub struct WidgetID {
     component_id: u32,
     widget_id: u32,
@@ -22,12 +22,12 @@ impl ToTokens for WidgetID {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let component_id = self.component_id;
         let widget_id = self.widget_id;
-        tokens.extend(quote!(::gui::gui_core::widget::WidgetID::new(#component_id, #widget_id)))
+        tokens.extend(quote!(WidgetID::new(#component_id, #widget_id)))
     }
 }
 
 impl WidgetID {
-    pub fn new(component_id: u32, widget_id: u32) -> Self {
+    pub const fn new(component_id: u32, widget_id: u32) -> Self {
         WidgetID {
             component_id,
             widget_id,

--- a/gui-core/src/widget.rs
+++ b/gui-core/src/widget.rs
@@ -1,4 +1,4 @@
-pub use crate::handles::{EventHandle, RenderHandle, ResizeHandle};
+pub use crate::handles::{EventHandle, RenderHandle, ResizeHandle, Handle};
 use crate::layout::LayoutConstraints;
 use crate::parse::fluent::Fluent;
 use crate::parse::WidgetDeclaration;

--- a/gui-core/src/widget.rs
+++ b/gui-core/src/widget.rs
@@ -58,7 +58,7 @@ pub trait Widget<C: Component> {
     fn id(&self) -> WidgetID;
     fn render(&mut self, scene: &mut SceneBuilder, handle: &mut RenderHandle<C>);
     fn resize(&mut self, constraints: LayoutConstraints, handle: &mut ResizeHandle<C>) -> Size;
-    fn event(&self, event: WidgetEvent, handle: &mut EventHandle<C>);
+    fn event(&mut self, event: WidgetEvent, handle: &mut EventHandle<C>);
 }
 
 impl<C: Component> Widget<C> for WidgetID {
@@ -69,7 +69,7 @@ impl<C: Component> Widget<C> for WidgetID {
     fn resize(&mut self, constraints: LayoutConstraints, _handle: &mut ResizeHandle<C>) -> Size {
         constraints.get_min()
     }
-    fn event(&self, _event: WidgetEvent, _handle: &mut EventHandle<C>) {}
+    fn event(&mut self, _event: WidgetEvent, _handle: &mut EventHandle<C>) {}
 }
 
 /// Helper trait to enable trait upcasting, since upcasting is not stable.

--- a/gui-core/src/widget.rs
+++ b/gui-core/src/widget.rs
@@ -1,8 +1,8 @@
-pub use crate::handles::{EventHandle, RenderHandle, ResizeHandle, Handle};
+pub use crate::handles::{EventHandle, Handle, RenderHandle, ResizeHandle};
 use crate::layout::LayoutConstraints;
 use crate::parse::fluent::Fluent;
 use crate::parse::WidgetDeclaration;
-use crate::Component;
+use crate::ToComponent;
 use dyn_clone::DynClone;
 use glazier::kurbo::Point;
 use glazier::PointerEvent;
@@ -63,22 +63,22 @@ impl<'a> WidgetEvent<'a> {
     }
 }
 
-pub trait Widget<C: Component> {
+pub trait Widget<T: ToComponent> {
     fn id(&self) -> WidgetID;
-    fn render(&mut self, scene: &mut SceneBuilder, handle: &mut RenderHandle<C>);
-    fn resize(&mut self, constraints: LayoutConstraints, handle: &mut ResizeHandle<C>) -> Size;
-    fn event(&mut self, event: WidgetEvent, handle: &mut EventHandle<C>);
+    fn render(&mut self, scene: &mut SceneBuilder, handle: &mut RenderHandle<T>);
+    fn resize(&mut self, constraints: LayoutConstraints, handle: &mut ResizeHandle<T>) -> Size;
+    fn event(&mut self, event: WidgetEvent, handle: &mut EventHandle<T>);
 }
 
-impl<C: Component> Widget<C> for WidgetID {
+impl<T: ToComponent> Widget<T> for WidgetID {
     fn id(&self) -> WidgetID {
         *self
     }
-    fn render(&mut self, _scene: &mut SceneBuilder, _handle: &mut RenderHandle<C>) {}
-    fn resize(&mut self, constraints: LayoutConstraints, _handle: &mut ResizeHandle<C>) -> Size {
+    fn render(&mut self, _scene: &mut SceneBuilder, _handle: &mut RenderHandle<T>) {}
+    fn resize(&mut self, constraints: LayoutConstraints, _handle: &mut ResizeHandle<T>) -> Size {
         constraints.get_min()
     }
-    fn event(&mut self, _event: WidgetEvent, _handle: &mut EventHandle<C>) {}
+    fn event(&mut self, _event: WidgetEvent, _handle: &mut EventHandle<T>) {}
 }
 
 /// Helper trait to enable trait upcasting, since upcasting is not stable.

--- a/gui-core/src/widget.rs
+++ b/gui-core/src/widget.rs
@@ -7,6 +7,7 @@ use dyn_clone::DynClone;
 use glazier::kurbo::Point;
 use glazier::PointerEvent;
 use proc_macro2::{Ident, TokenStream};
+use quote::{quote, ToTokens};
 use std::any::Any;
 use vello::kurbo::Size;
 use vello::SceneBuilder;
@@ -15,6 +16,14 @@ use vello::SceneBuilder;
 pub struct WidgetID {
     component_id: u32,
     widget_id: u32,
+}
+
+impl ToTokens for WidgetID {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let component_id = self.component_id;
+        let widget_id = self.widget_id;
+        tokens.extend(quote!(::gui::gui_core::widget::WidgetID::new(#component_id, #widget_id)))
+    }
 }
 
 impl WidgetID {
@@ -94,8 +103,7 @@ pub trait WidgetBuilder: std::fmt::Debug + AsAny + DynClone {
     );
     fn name(&self) -> &'static str;
     fn combine(&mut self, rhs: &dyn WidgetBuilder);
-    fn create_widget(&self, widget: Option<&TokenStream>, stream: &mut TokenStream);
-
+    fn create_widget(&self, id: WidgetID, widget: Option<&TokenStream>, stream: &mut TokenStream);
     fn on_property_update(
         &self,
         property: &'static str,

--- a/gui-widget/src/button.rs
+++ b/gui-widget/src/button.rs
@@ -1,4 +1,5 @@
 use gui_core::glazier::kurbo::{Shape, Size};
+use gui_core::glazier::Cursor;
 use gui_core::layout::LayoutConstraints;
 use gui_core::parse::fluent::Fluent;
 use gui_core::parse::WidgetDeclaration;
@@ -184,9 +185,9 @@ impl<T: ToHandler<BaseHandler = C>, C: ToComponent + ButtonHandler<T>, W: Widget
         });
         match event {
             WidgetEvent::PointerUp(_) => {
+                handle.set_active(self.id(), false);
+                handle.invalidate_id(self.id());
                 if hit {
-                    handle.set_active(self.id(), false);
-                    handle.invalidate_id(self.id());
                     handle.get_handler().on_press();
                 }
             }
@@ -197,8 +198,11 @@ impl<T: ToHandler<BaseHandler = C>, C: ToComponent + ButtonHandler<T>, W: Widget
                 }
             }
             WidgetEvent::PointerMove(_) => {
-                if hit && handle.add_hover(self.id()) {
-                    handle.invalidate_id(self.id());
+                if hit {
+                    handle.set_cursor(&Cursor::Pointer);
+                    if handle.add_hover(self.id()) {
+                        handle.invalidate_id(self.id());
+                    }
                 }
             }
             WidgetEvent::HoverChange | WidgetEvent::ActiveChange => handle.invalidate_id(self.id()),

--- a/gui-widget/src/button.rs
+++ b/gui-widget/src/button.rs
@@ -6,7 +6,7 @@ use gui_core::vello::kurbo::{Affine, Vec2};
 use gui_core::vello::peniko::{BlendMode, Brush, Color, Compose, Fill, Mix, Stroke};
 use gui_core::vello::SceneFragment;
 use gui_core::widget::{RenderHandle, ResizeHandle, Widget, WidgetBuilder, WidgetEvent, WidgetID};
-use gui_core::{widget, Colour, Component, SceneBuilder, ToHandler, Var};
+use gui_core::{widget, Colour, SceneBuilder, ToComponent, ToHandler, Var};
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, ToTokens};
 use serde::Deserialize;
@@ -17,7 +17,7 @@ pub trait ButtonHandler<T: ToHandler<BaseHandler = Self>> {
     fn on_press(&mut self) {}
 }
 
-pub struct Button<T: ToHandler<BaseHandler = C::Handler>, C: Component, W: Widget<C>> {
+pub struct Button<T: ToHandler<BaseHandler = C>, C: ToComponent, W: Widget<C>> {
     id: WidgetID,
     background_colour: Colour,
     disabled_colour: Colour,
@@ -29,7 +29,7 @@ pub struct Button<T: ToHandler<BaseHandler = C::Handler>, C: Component, W: Widge
     phantom: PhantomData<(T, C)>,
 }
 
-impl<T: ToHandler<BaseHandler = C::Handler>, C: Component, W: Widget<C>> Button<T, C, W> {
+impl<T: ToHandler<BaseHandler = C>, C: ToComponent, W: Widget<C>> Button<T, C, W> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: WidgetID,
@@ -79,10 +79,8 @@ impl<T: ToHandler<BaseHandler = C::Handler>, C: Component, W: Widget<C>> Button<
 
 const STOKE_WIDTH: f64 = 0.58;
 
-impl<T: ToHandler<BaseHandler = C::Handler>, C: Component, W: Widget<C>> Widget<C>
+impl<T: ToHandler<BaseHandler = C>, C: ToComponent + ButtonHandler<T>, W: Widget<C>> Widget<C>
     for Button<T, C, W>
-where
-    C::Handler: ButtonHandler<T>,
 {
     fn id(&self) -> WidgetID {
         self.id

--- a/gui-widget/src/button.rs
+++ b/gui-widget/src/button.rs
@@ -77,6 +77,8 @@ const STOKE_WIDTH: f64 = 0.58;
 
 impl<T: ToHandler<BaseHandler = C::Handler>, C: Component, W: Widget<C>> Widget<C>
     for Button<T, C, W>
+where
+    C::Handler: ButtonHandler<T>,
 {
     fn id(&self) -> WidgetID {
         todo!()
@@ -113,7 +115,7 @@ impl<T: ToHandler<BaseHandler = C::Handler>, C: Component, W: Widget<C>> Widget<
 
         let mut fragment = SceneFragment::new();
         let mut builder = SceneBuilder::for_fragment(&mut fragment);
-        handle.render_widgets(&mut builder, [&self.child]);
+        handle.render_widgets(&mut builder, [&mut self.child].into_iter());
 
         scene.append(
             &fragment,
@@ -160,11 +162,11 @@ impl<T: ToHandler<BaseHandler = C::Handler>, C: Component, W: Widget<C>> Widget<
         child_size
     }
 
-    fn event(&self, event: WidgetEvent, handle: &mut EventHandle<C>) {
+    fn event(&mut self, event: WidgetEvent, handle: &mut EventHandle<C>) {
         if self.disabled {
             return;
         }
-        let hit = event.get_point().map_or_else(false, |pos| {
+        let hit = event.get_point().map_or(false, |pos| {
             handle
                 .get_global_rect(self.id())
                 .to_rounded_rect(4.0)

--- a/gui-widget/src/button.rs
+++ b/gui-widget/src/button.rs
@@ -5,7 +5,9 @@ use gui_core::parse::WidgetDeclaration;
 use gui_core::vello::kurbo::{Affine, Vec2};
 use gui_core::vello::peniko::{BlendMode, Brush, Color, Compose, Fill, Mix, Stroke};
 use gui_core::vello::SceneFragment;
-use gui_core::widget::{RenderHandle, ResizeHandle, Widget, WidgetBuilder, WidgetEvent, WidgetID};
+use gui_core::widget::{
+    RenderHandle, ResizeHandle, UpdateHandle, Widget, WidgetBuilder, WidgetEvent, WidgetID,
+};
 use gui_core::{widget, Colour, SceneBuilder, ToComponent, ToHandler, Var};
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, ToTokens};
@@ -54,23 +56,29 @@ impl<T: ToHandler<BaseHandler = C>, C: ToComponent, W: Widget<C>> Button<T, C, W
         }
     }
 
-    pub fn set_disabled(&mut self, disabled: bool) {
+    pub fn set_disabled(&mut self, disabled: bool, handle: &mut UpdateHandle) {
         self.disabled = disabled;
+        handle.invalidate_id(self.id)
     }
-    pub fn set_background_colour(&mut self, colour: Colour) {
+    pub fn set_background_colour(&mut self, colour: Colour, handle: &mut UpdateHandle) {
         self.background_colour = colour;
+        handle.invalidate_id(self.id)
     }
-    pub fn set_disabled_colour(&mut self, colour: Colour) {
+    pub fn set_disabled_colour(&mut self, colour: Colour, handle: &mut UpdateHandle) {
         self.disabled_colour = colour;
+        handle.invalidate_id(self.id)
     }
-    pub fn set_clicked_colour(&mut self, colour: Colour) {
+    pub fn set_clicked_colour(&mut self, colour: Colour, handle: &mut UpdateHandle) {
         self.clicked_colour = colour;
+        handle.invalidate_id(self.id)
     }
-    pub fn set_hover_colour(&mut self, colour: Colour) {
+    pub fn set_hover_colour(&mut self, colour: Colour, handle: &mut UpdateHandle) {
         self.hover_colour = colour;
+        handle.invalidate_id(self.id)
     }
-    pub fn set_border_colour(&mut self, colour: Colour) {
+    pub fn set_border_colour(&mut self, colour: Colour, handle: &mut UpdateHandle) {
         self.border_colour = colour;
+        handle.invalidate_id(self.id)
     }
     pub fn get_widget(&mut self) -> &mut W {
         &mut self.child
@@ -284,15 +292,22 @@ impl WidgetBuilder for ButtonBuilder {
         property: &'static str,
         widget: &Ident,
         value: &Ident,
+        handle: &Ident,
         stream: &mut TokenStream,
     ) {
         match property {
-            "disabled" => stream.extend(quote! {#widget.set_disabled(#value);}),
-            "background_colour" => stream.extend(quote! {#widget.set_background_colour(#value);}),
-            "disabled_colour" => stream.extend(quote! {#widget.set_disabled_colour(#value);}),
-            "clicked_colour" => stream.extend(quote! {#widget.set_clicked_colour(#value);}),
-            "hover_colour" => stream.extend(quote! {#widget.set_hover_colour(#value);}),
-            "border_colour" => stream.extend(quote! {#widget.set_border_colour(#value);}),
+            "disabled" => stream.extend(quote! {#widget.set_disabled(#value, #handle);}),
+            "background_colour" => {
+                stream.extend(quote! {#widget.set_background_colour(#value, #handle);})
+            }
+            "disabled_colour" => {
+                stream.extend(quote! {#widget.set_disabled_colour(#value, #handle);})
+            }
+            "clicked_colour" => {
+                stream.extend(quote! {#widget.set_clicked_colour(#value, #handle);})
+            }
+            "hover_colour" => stream.extend(quote! {#widget.set_hover_colour(#value, #handle);}),
+            "border_colour" => stream.extend(quote! {#widget.set_border_colour(#value, #handle);}),
             _ => {}
         }
     }

--- a/gui-widget/src/button.rs
+++ b/gui-widget/src/button.rs
@@ -18,6 +18,7 @@ pub trait ButtonHandler<T: ToHandler<BaseHandler = Self>> {
 }
 
 pub struct Button<T: ToHandler<BaseHandler = C::Handler>, C: Component, W: Widget<C>> {
+    id: WidgetID,
     background_colour: Colour,
     disabled_colour: Colour,
     clicked_colour: Colour,
@@ -29,7 +30,9 @@ pub struct Button<T: ToHandler<BaseHandler = C::Handler>, C: Component, W: Widge
 }
 
 impl<T: ToHandler<BaseHandler = C::Handler>, C: Component, W: Widget<C>> Button<T, C, W> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
+        id: WidgetID,
         background_colour: Colour,
         disabled_colour: Colour,
         clicked_colour: Colour,
@@ -39,6 +42,7 @@ impl<T: ToHandler<BaseHandler = C::Handler>, C: Component, W: Widget<C>> Button<
         child: W,
     ) -> Self {
         Button {
+            id,
             background_colour,
             disabled_colour,
             clicked_colour,
@@ -81,7 +85,7 @@ where
     C::Handler: ButtonHandler<T>,
 {
     fn id(&self) -> WidgetID {
-        todo!()
+        self.id
     }
 
     fn render(&mut self, scene: &mut SceneBuilder, handle: &mut RenderHandle<C>) {
@@ -246,7 +250,7 @@ impl WidgetBuilder for ButtonBuilder {
         }
     }
 
-    fn create_widget(&self, widget: Option<&TokenStream>, stream: &mut TokenStream) {
+    fn create_widget(&self, id: WidgetID, widget: Option<&TokenStream>, stream: &mut TokenStream) {
         let background_colour = match &self.background_colour {
             Some(Var::Value(v)) => v.to_token_stream(),
             _ => Colour(Color::WHITE).to_token_stream(),
@@ -273,7 +277,7 @@ impl WidgetBuilder for ButtonBuilder {
         };
 
         stream.extend(quote! {
-            ::gui::gui_widget::Button::new(#background_colour, #disabled_colour, #clicked_colour, #hover_colour, #border_colour, #disabled, #widget)
+            ::gui::gui_widget::Button::new(#id, #background_colour, #disabled_colour, #clicked_colour, #hover_colour, #border_colour, #disabled, #widget)
         });
     }
 

--- a/gui-widget/src/hvstack.rs
+++ b/gui-widget/src/hvstack.rs
@@ -4,7 +4,7 @@ use gui_core::parse::WidgetDeclaration;
 use gui_core::widget::{
     EventHandle, RenderHandle, ResizeHandle, Widget, WidgetBuilder, WidgetEvent, WidgetID,
 };
-use gui_core::{Component, LayoutConstraints, Point, SceneBuilder, Size, Var};
+use gui_core::{LayoutConstraints, Point, SceneBuilder, Size, ToComponent, Var};
 use itertools::Itertools;
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, ToTokens};
@@ -39,7 +39,7 @@ impl Axis {
     }
 }
 
-pub struct HVStack<C: Component, W: Widget<C>> {
+pub struct HVStack<C: ToComponent, W: Widget<C>> {
     id: WidgetID,
     axis: Axis,
     spacing: f32,
@@ -47,7 +47,7 @@ pub struct HVStack<C: Component, W: Widget<C>> {
     phantom: PhantomData<C>,
 }
 
-impl<C: Component, W: Widget<C>> HVStack<C, W> {
+impl<C: ToComponent, W: Widget<C>> HVStack<C, W> {
     pub fn new_horizontal(id: WidgetID, spacing: f32, children: Vec<W>) -> Self {
         Self {
             id,
@@ -77,7 +77,7 @@ impl<C: Component, W: Widget<C>> HVStack<C, W> {
     }
 }
 
-impl<C: Component, W: Widget<C>> Widget<C> for HVStack<C, W> {
+impl<C: ToComponent, W: Widget<C>> Widget<C> for HVStack<C, W> {
     fn id(&self) -> WidgetID {
         self.id
     }

--- a/gui-widget/src/hvstack.rs
+++ b/gui-widget/src/hvstack.rs
@@ -1,10 +1,10 @@
-use gui_core::glazier::kurbo::{Affine, Rect};
-use gui_core::glazier::{PointerEvent, WindowHandle};
+use gui_core::glazier::kurbo::Rect;
 use gui_core::parse::fluent::Fluent;
 use gui_core::parse::WidgetDeclaration;
-use gui_core::vello::SceneFragment;
-use gui_core::widget::{Widget, WidgetBuilder};
-use gui_core::{FontContext, LayoutConstraints, Point, SceneBuilder, Size, Var};
+use gui_core::widget::{
+    EventHandle, RenderHandle, ResizeHandle, Widget, WidgetBuilder, WidgetEvent, WidgetID,
+};
+use gui_core::{Component, LayoutConstraints, Point, SceneBuilder, Size, Var};
 use itertools::Itertools;
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, ToTokens};
@@ -39,21 +39,19 @@ impl Axis {
     }
 }
 
-pub struct HVStack<C, W: Widget<C>> {
+pub struct HVStack<C: Component, W: Widget<C>> {
     axis: Axis,
     spacing: f32,
     children: Vec<W>,
-    positions: Vec<Rect>,
     phantom: PhantomData<C>,
 }
 
-impl<C, W: Widget<C>> HVStack<C, W> {
+impl<C: Component, W: Widget<C>> HVStack<C, W> {
     pub fn new_horizontal(spacing: f32, children: Vec<W>) -> Self {
         Self {
             axis: Axis::Horizontal,
             spacing,
             children,
-            positions: vec![],
             phantom: PhantomData,
         }
     }
@@ -63,7 +61,6 @@ impl<C, W: Widget<C>> HVStack<C, W> {
             axis: Axis::Vertical,
             spacing,
             children,
-            positions: vec![],
             phantom: PhantomData,
         }
     }
@@ -75,31 +72,17 @@ impl<C, W: Widget<C>> HVStack<C, W> {
     pub fn widgets(&mut self, i: usize) -> &mut W {
         self.children.get_mut(i).unwrap()
     }
-
-    fn hitcast(&mut self, pos: Point) -> Option<(Point, &mut W)> {
-        self.positions
-            .iter()
-            .find_position(|p| p.contains(pos))
-            .and_then(|(i, p)| {
-                self.children
-                    .get_mut(i)
-                    .map(|c| ((pos - p.origin()).to_point(), c))
-            })
-    }
 }
 
-impl<C, W: Widget<C>> Widget<C> for HVStack<C, W> {
-    fn render(&mut self, scene: &mut SceneBuilder, fcx: &mut FontContext) {
-        for (child, pos) in self.children.iter_mut().zip(self.positions.iter()) {
-            let mut fragment = SceneFragment::new();
-            let mut builder = SceneBuilder::for_fragment(&mut fragment);
-            child.render(&mut builder, fcx);
-
-            scene.append(&fragment, Some(Affine::translate(pos.origin().to_vec2())));
-        }
+impl<C: Component, W: Widget<C>> Widget<C> for HVStack<C, W> {
+    fn id(&self) -> WidgetID {
+        todo!()
     }
 
-    fn resize(&mut self, constraints: LayoutConstraints, fcx: &mut FontContext) -> Size {
+    fn render(&mut self, scene: &mut SceneBuilder, handle: &mut RenderHandle<C>) {
+        handle.render_widgets(scene, self.children.iter_mut());
+    }
+    fn resize(&mut self, constraints: LayoutConstraints, handle: &mut ResizeHandle<C>) -> Size {
         let child_length = self.children.len();
         let total_spacing = self.spacing as f64 * (child_length - 1) as f64;
         let mut remaining = constraints.map(|s| s - self.axis.to_size(total_spacing));
@@ -115,81 +98,48 @@ impl<C, W: Widget<C>> Widget<C> for HVStack<C, W> {
                         Axis::Vertical => remaining
                             .map(|s| Size::new(s.width, s.height / (child_length - i) as f64)),
                     };
-                    let size = child.resize(allocated_space, fcx);
+                    let size = child.resize(allocated_space, handle);
                     remaining = remaining.map(|s| s - self.axis.to_size(self.axis.get_axis(size)));
-                    size
+                    (size, child.id())
                 })
                 .collect_vec();
 
         let max_length = layouts
             .iter()
-            .map(|s| self.axis.invert().get_axis(*s))
+            .map(|(s, _)| self.axis.invert().get_axis(*s))
             .reduce(f64::max)
             .unwrap_or_default();
         let mut acc = 0.0;
 
-        self.positions = layouts
-            .iter()
-            .map(|s| {
-                let pos = match self.axis {
-                    Axis::Horizontal => {
-                        Point::new(acc, (max_length - self.axis.invert().get_axis(*s)) / 2.0)
-                    }
-                    Axis::Vertical => {
-                        Point::new((max_length - self.axis.invert().get_axis(*s)) / 2.0, acc)
-                    }
-                };
-                acc += self.axis.get_axis(*s) + self.spacing as f64;
-                Rect::from_origin_size(pos, *s)
-            })
-            .collect_vec();
+        for (s, id) in layouts.iter().copied() {
+            let pos = match self.axis {
+                Axis::Horizontal => {
+                    Point::new(acc, (max_length - self.axis.invert().get_axis(s)) / 2.0)
+                }
+                Axis::Vertical => {
+                    Point::new((max_length - self.axis.invert().get_axis(s)) / 2.0, acc)
+                }
+            };
+            acc += self.axis.get_axis(s) + self.spacing as f64;
+            handle.position_widget(Rect::from_origin_size(pos, s), id)
+        }
 
         match self.axis {
             Axis::Horizontal => Size::new(
-                Itertools::intersperse(layouts.iter().map(|s| s.width), self.spacing as f64).sum(),
+                Itertools::intersperse(layouts.iter().map(|(s, _)| s.width), self.spacing as f64)
+                    .sum(),
                 max_length,
             ),
             Axis::Vertical => Size::new(
                 max_length,
-                Itertools::intersperse(layouts.iter().map(|s| s.height), self.spacing as f64).sum(),
+                Itertools::intersperse(layouts.iter().map(|(s, _)| s.height), self.spacing as f64)
+                    .sum(),
             ),
         }
     }
 
-    fn pointer_down(
-        &mut self,
-        local_pos: Point,
-        event: &PointerEvent,
-        window: &WindowHandle,
-        handler: &mut C,
-    ) {
-        if let Some((new_pos, w)) = self.hitcast(local_pos) {
-            w.pointer_down(new_pos, event, window, handler)
-        }
-    }
-
-    fn pointer_up(
-        &mut self,
-        local_pos: Point,
-        event: &PointerEvent,
-        window: &WindowHandle,
-        handler: &mut C,
-    ) {
-        if let Some((new_pos, w)) = self.hitcast(local_pos) {
-            w.pointer_up(new_pos, event, window, handler)
-        }
-    }
-
-    fn pointer_move(
-        &mut self,
-        local_pos: Point,
-        event: &PointerEvent,
-        window: &WindowHandle,
-        handler: &mut C,
-    ) {
-        if let Some((new_pos, w)) = self.hitcast(local_pos) {
-            w.pointer_move(new_pos, event, window, handler)
-        }
+    fn event(&mut self, event: WidgetEvent, handle: &mut EventHandle<C>) {
+        handle.propagate_event(event, self.children.iter_mut())
     }
 }
 

--- a/gui-widget/src/hvstack.rs
+++ b/gui-widget/src/hvstack.rs
@@ -40,6 +40,7 @@ impl Axis {
 }
 
 pub struct HVStack<C: Component, W: Widget<C>> {
+    id: WidgetID,
     axis: Axis,
     spacing: f32,
     children: Vec<W>,
@@ -47,8 +48,9 @@ pub struct HVStack<C: Component, W: Widget<C>> {
 }
 
 impl<C: Component, W: Widget<C>> HVStack<C, W> {
-    pub fn new_horizontal(spacing: f32, children: Vec<W>) -> Self {
+    pub fn new_horizontal(id: WidgetID, spacing: f32, children: Vec<W>) -> Self {
         Self {
+            id,
             axis: Axis::Horizontal,
             spacing,
             children,
@@ -56,8 +58,9 @@ impl<C: Component, W: Widget<C>> HVStack<C, W> {
         }
     }
 
-    pub fn new_vertical(spacing: f32, children: Vec<W>) -> Self {
+    pub fn new_vertical(id: WidgetID, spacing: f32, children: Vec<W>) -> Self {
         Self {
+            id,
             axis: Axis::Vertical,
             spacing,
             children,
@@ -76,7 +79,7 @@ impl<C: Component, W: Widget<C>> HVStack<C, W> {
 
 impl<C: Component, W: Widget<C>> Widget<C> for HVStack<C, W> {
     fn id(&self) -> WidgetID {
-        todo!()
+        self.id
     }
 
     fn render(&mut self, scene: &mut SceneBuilder, handle: &mut RenderHandle<C>) {
@@ -174,14 +177,14 @@ impl WidgetBuilder for HStackBuilder {
         }
     }
 
-    fn create_widget(&self, widget: Option<&TokenStream>, stream: &mut TokenStream) {
+    fn create_widget(&self, id: WidgetID, widget: Option<&TokenStream>, stream: &mut TokenStream) {
         let spacing = match &self.spacing {
             Some(Var::Value(v)) => v.to_token_stream(),
             _ => 0_10f32.to_token_stream(),
         };
 
         stream.extend(quote! {
-            ::gui::gui_widget::HVStack::new_horizontal(#spacing, vec![#widget])
+            ::gui::gui_widget::HVStack::new_horizontal(#id, #spacing, vec![#widget])
         });
     }
 
@@ -261,14 +264,14 @@ impl WidgetBuilder for VStackBuilder {
         }
     }
 
-    fn create_widget(&self, widget: Option<&TokenStream>, stream: &mut TokenStream) {
+    fn create_widget(&self, id: WidgetID, widget: Option<&TokenStream>, stream: &mut TokenStream) {
         let spacing = match &self.spacing {
             Some(Var::Value(v)) => v.to_token_stream(),
             _ => 0_10f32.to_token_stream(),
         };
 
         stream.extend(quote! {
-            ::gui::gui_widget::HVStack::new_vertical(#spacing, vec![#widget])
+            ::gui::gui_widget::HVStack::new_vertical(#id, #spacing, vec![#widget])
         });
     }
 

--- a/gui-widget/src/hvstack.rs
+++ b/gui-widget/src/hvstack.rs
@@ -1,9 +1,7 @@
 use gui_core::glazier::kurbo::Rect;
 use gui_core::parse::fluent::Fluent;
 use gui_core::parse::WidgetDeclaration;
-use gui_core::widget::{
-    EventHandle, RenderHandle, ResizeHandle, Widget, WidgetBuilder, WidgetEvent, WidgetID,
-};
+use gui_core::widget::{EventHandle, RenderHandle, ResizeHandle, UpdateHandle, Widget, WidgetBuilder, WidgetEvent, WidgetID};
 use gui_core::{LayoutConstraints, Point, SceneBuilder, Size, ToComponent, Var};
 use itertools::Itertools;
 use proc_macro2::{Ident, TokenStream};
@@ -68,8 +66,9 @@ impl<C: ToComponent, W: Widget<C>> HVStack<C, W> {
         }
     }
 
-    pub fn set_spacing(&mut self, spacing: f32) {
+    pub fn set_spacing(&mut self, spacing: f32, handle: &mut UpdateHandle) {
         self.spacing = spacing;
+        handle.invalidate_id(self.id);
     }
 
     pub fn widgets(&mut self, i: usize) -> &mut W {
@@ -193,11 +192,12 @@ impl WidgetBuilder for HStackBuilder {
         property: &'static str,
         widget: &Ident,
         value: &Ident,
+        handle: &Ident,
         stream: &mut TokenStream,
     ) {
         #[allow(clippy::single_match)]
         match property {
-            "spacing" => stream.extend(quote! {#widget.set_disabled(#value);}),
+            "spacing" => stream.extend(quote! {#widget.set_spacing(#value, #handle);}),
             _ => {}
         }
     }
@@ -280,11 +280,12 @@ impl WidgetBuilder for VStackBuilder {
         property: &'static str,
         widget: &Ident,
         value: &Ident,
+        handle: &Ident,
         stream: &mut TokenStream,
     ) {
         #[allow(clippy::single_match)]
         match property {
-            "spacing" => stream.extend(quote! {#widget.set_disabled(#value);}),
+            "spacing" => stream.extend(quote! {#widget.set_spacing(#value, #handle);}),
             _ => {}
         }
     }

--- a/gui-widget/src/hvstack.rs
+++ b/gui-widget/src/hvstack.rs
@@ -1,7 +1,10 @@
 use gui_core::glazier::kurbo::Rect;
 use gui_core::parse::fluent::Fluent;
 use gui_core::parse::WidgetDeclaration;
-use gui_core::widget::{EventHandle, RenderHandle, ResizeHandle, UpdateHandle, Widget, WidgetBuilder, WidgetEvent, WidgetID};
+use gui_core::widget::{
+    EventHandle, RenderHandle, ResizeHandle, UpdateHandle, Widget, WidgetBuilder, WidgetEvent,
+    WidgetID,
+};
 use gui_core::{LayoutConstraints, Point, SceneBuilder, Size, ToComponent, Var};
 use itertools::Itertools;
 use proc_macro2::{Ident, TokenStream};

--- a/gui-widget/src/text.rs
+++ b/gui-widget/src/text.rs
@@ -9,8 +9,10 @@ use gui_core::parse::fluent::Fluent;
 use gui_core::parse::WidgetDeclaration;
 use gui_core::vello::kurbo::Affine;
 use gui_core::vello::peniko::{Brush, Color};
-use gui_core::widget::{Widget, WidgetBuilder};
-use gui_core::{Colour, FontContext, SceneBuilder, Var};
+use gui_core::widget::{
+    EventHandle, RenderHandle, ResizeHandle, Widget, WidgetBuilder, WidgetEvent, WidgetID,
+};
+use gui_core::{Colour, Component, FontContext, SceneBuilder, Var};
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, ToTokens};
 use serde::Deserialize;
@@ -66,30 +68,36 @@ impl Text {
     }
 }
 
-impl<T> Widget<T> for Text {
-    fn render(&mut self, scene: &mut SceneBuilder, fcx: &mut FontContext) {
+impl<C: Component> Widget<C> for Text {
+    fn id(&self) -> WidgetID {
+        todo!()
+    }
+
+    fn render(&mut self, scene: &mut SceneBuilder, handle: &mut RenderHandle<C>) {
         if self.layout.is_none() {
             if self.text.is_empty() {
                 return;
             }
-            self.build(fcx);
+            self.build(handle.get_fcx());
         }
 
         let layout = self.layout.as_mut().unwrap();
         text::render_text(scene, Affine::translate((0.0, 0.0)), layout);
     }
 
-    fn resize(&mut self, constraints: LayoutConstraints, fcx: &mut FontContext) -> Size {
+    fn resize(&mut self, constraints: LayoutConstraints, handle: &mut ResizeHandle<C>) -> Size {
         if self.layout.is_none() {
             if self.text.is_empty() {
                 return Size::ZERO;
             }
-            self.build(fcx);
+            self.build(handle.get_fcx());
         }
         let layout = self.layout.as_mut().unwrap();
         layout.break_all_lines(constraints.max_advance(), Alignment::Start);
         Size::new(layout.width() as f64, layout.height() as f64)
     }
+
+    fn event(&mut self, _event: WidgetEvent, _handle: &mut EventHandle<C>) {}
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/gui-widget/src/text.rs
+++ b/gui-widget/src/text.rs
@@ -19,6 +19,7 @@ use serde::Deserialize;
 use std::borrow::Cow;
 
 pub struct Text {
+    id: WidgetID,
     text: String,
     colour: Colour,
     size: f32,
@@ -26,9 +27,10 @@ pub struct Text {
 }
 
 impl Text {
-    pub fn new(text: String, colour: Colour, size: f32) -> Self {
+    pub fn new(id: WidgetID, colour: Colour, size: f32) -> Self {
         Text {
-            text,
+            id,
+            text: String::new(),
             colour,
             size,
             layout: None,
@@ -70,7 +72,7 @@ impl Text {
 
 impl<C: Component> Widget<C> for Text {
     fn id(&self) -> WidgetID {
-        todo!()
+        self.id
     }
 
     fn render(&mut self, scene: &mut SceneBuilder, handle: &mut RenderHandle<C>) {
@@ -137,7 +139,7 @@ impl WidgetBuilder for TextBuilder {
         }
     }
 
-    fn create_widget(&self, _widget: Option<&TokenStream>, stream: &mut TokenStream) {
+    fn create_widget(&self, id: WidgetID, _widget: Option<&TokenStream>, stream: &mut TokenStream) {
         let colour = match &self.colour {
             Some(Var::Value(v)) => v.to_token_stream(),
             _ => Colour(Color::rgb8(33, 37, 41)).to_token_stream(),
@@ -148,7 +150,7 @@ impl WidgetBuilder for TextBuilder {
         };
 
         stream.extend(quote! {
-            ::gui::gui_widget::Text::new(String::new(), #colour, #size)
+            ::gui::gui_widget::Text::new(#id, #colour, #size)
         });
     }
 

--- a/gui-widget/src/text.rs
+++ b/gui-widget/src/text.rs
@@ -84,7 +84,7 @@ impl<C: ToComponent> Widget<C> for Text {
         }
 
         let layout = self.layout.as_mut().unwrap();
-        text::render_text(scene, Affine::translate((0.0, 0.0)), layout);
+        text::render_text(scene, Affine::IDENTITY, layout);
     }
 
     fn resize(&mut self, constraints: LayoutConstraints, handle: &mut ResizeHandle<C>) -> Size {

--- a/gui-widget/src/text.rs
+++ b/gui-widget/src/text.rs
@@ -12,7 +12,7 @@ use gui_core::vello::peniko::{Brush, Color};
 use gui_core::widget::{
     EventHandle, RenderHandle, ResizeHandle, Widget, WidgetBuilder, WidgetEvent, WidgetID,
 };
-use gui_core::{Colour, Component, FontContext, SceneBuilder, Var};
+use gui_core::{Colour, FontContext, SceneBuilder, ToComponent, Var};
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, ToTokens};
 use serde::Deserialize;
@@ -70,7 +70,7 @@ impl Text {
     }
 }
 
-impl<C: Component> Widget<C> for Text {
+impl<C: ToComponent> Widget<C> for Text {
     fn id(&self) -> WidgetID {
         self.id
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,8 @@ impl<C: Component> WindowState<C> {
                 )),
             );
 
+            println!("HIya");
+
             self.renderer
                 .get_or_insert_with(|| Renderer::new(device, &renderer_options).unwrap())
                 .render_to_surface(device, queue, &self.scene, &surface_texture, &render_params)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,10 +80,6 @@ impl<C: Component> WindowState<C> {
         }
     }
 
-    fn schedule_render(&self) {
-        self.handle.window.invalidate();
-    }
-
     fn resize(&mut self) {
         let (max_width, max_height) = self.surface_size();
         let mut local_positions =
@@ -186,16 +182,15 @@ impl<C: Component + 'static> WinHandler for WindowState<C> {
 
     fn size(&mut self, size: Size) {
         self.size = size;
+        self.resize();
     }
 
     fn prepare_paint(&mut self) {
         self.component.update_vars(false);
-        self.resize();
     }
 
     fn paint(&mut self, _: &Region) {
         self.render();
-        self.schedule_render();
     }
 
     fn command(&mut self, _id: u32) {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,10 @@ impl<C: Component> WindowState<C> {
             scene: Default::default(),
             active_widget: None,
             hovered_widgets: vec![],
-            global_positions: vec![Rect::default(); component.largest_id().widget_id() as usize],
+            global_positions: vec![
+                Rect::default();
+                component.largest_id().widget_id() as usize + 1
+            ],
             component,
             size: Size::new(800.0, 600.0),
         }
@@ -84,7 +87,7 @@ impl<C: Component> WindowState<C> {
     fn resize(&mut self) {
         let (max_width, max_height) = self.surface_size();
         let mut local_positions =
-            vec![Rect::default(); self.component.largest_id().widget_id() as usize];
+            vec![Rect::default(); self.component.largest_id().widget_id() as usize + 1];
         let size = self.component.resize(
             LayoutConstraints::new_max(Size::new(max_width as f64, max_height as f64)),
             &mut self.handle,


### PR DESCRIPTION
- Created new architecture as HStack's were previously not sending events down to their children
- Had to rechange the architecture due to lifetime issues (holding multiple mutable references at the same time). To fix this I decided to hold CompStructs in handles instead of Components and run any active change events afterwards.
- We now no longer re-render and re-layout the UI every frame, it's only done if the handle is notified
- `get_local_rect` was incorrect causing the buttons to look incorrect.
- Add different cursors when hovering over buttons
- Only pass mouse events to the active widget to prevent hover effects on different buttons whilst holding onto the button.